### PR TITLE
Change USER_WS to STUDIO_HOST_USER_WS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If that is the case, follow [these instructions](https://docs.picknik.ai/en/stab
 
 Otherwise, it is left to the user to ensure that the prerequites from the installation process have been met.
 
-To manually launch MoveIt Studio with the default configuration provided by this workspace, specify this repository as the target `USER_WS` in the provided [.env file](.env).
+To manually launch MoveIt Studio with the default configuration provided by this workspace, specify this repository as the target `STUDIO_HOST_USER_WORKSPACE` in the provided [.env file](.env).
 By default, `STUDIO_HOST_USER_WORKSPACE` points to `$HOME/moveit_studio_ws`.
 If you have cloned this repository to a different location, then update the line to point to this workspace.
 


### PR DESCRIPTION
The README has a reference to `USER_WS`, but we don't have a variable with this name in our `docker-compose*.yaml`. I believe this is supposed to be `STUDIO_HOST_USER_WS`, since that's what is in the `.env` file and also is what is mentioned on the following line.