### PR TITLE
Update standard tree nodes model for BT v4

### DIFF
--- a/src/picknik_ur_base_config/objectives/standard_tree_nodes_model.xml
+++ b/src/picknik_ur_base_config/objectives/standard_tree_nodes_model.xml
@@ -35,7 +35,7 @@
                 <p>The ParallelNode executes all its children concurrently, but not in separate threads!</p>
                 <p>Even if this may look similar to ReactiveSequence, this Control Node is the only one that can have multiple children RUNNING at the same time.</p>
                 <p>The Node is completed either when the THRESHOLD_SUCCESS or THRESHOLD_FAILURE number is reached (both configured using ports).</p>
-                <p> If any of the threaholds are reached, and other children are still running, they will be halted.</p>
+                <p> If any of the thresholds are reached, and other children are still running, they will be halted.</p>
             </description>
             <input_port name="success_count" default="">Number of children which need to succeed to trigger a SUCCESS.</input_port>
             <input_port name="failure_count" default="">Number of children which need to fail to trigger a FAILURE.</input_port>

--- a/src/picknik_ur_base_config/objectives/standard_tree_nodes_model.xml
+++ b/src/picknik_ur_base_config/objectives/standard_tree_nodes_model.xml
@@ -37,8 +37,8 @@
                 <p>The Node is completed either when the THRESHOLD_SUCCESS or THRESHOLD_FAILURE number is reached (both configured using ports).</p>
                 <p> If any of the threaholds are reached, and other children are still running, they will be halted.</p>
             </description>
-            <input_port name="success_threshold" default="">Number of children which need to succeed to trigger a SUCCESS.</input_port>
-            <input_port name="failure_threshold" default="">Number of children which need to fail to trigger a FAILURE.</input_port>
+            <input_port name="success_count" default="">Number of children which need to succeed to trigger a SUCCESS.</input_port>
+            <input_port name="failure_count" default="">Number of children which need to fail to trigger a FAILURE.</input_port>
         </Control>
         <Control ID="ReactiveSequence">
             <description>

--- a/src/picknik_ur_base_config/objectives/standard_tree_nodes_model.xml
+++ b/src/picknik_ur_base_config/objectives/standard_tree_nodes_model.xml
@@ -81,16 +81,15 @@
                 <p>If the 2nd or 3d child is RUNNING and the statement changes, the RUNNING child will be stopped before starting the sibling.</p>
             </description>
         </Control>
-        <Decorator ID="BlackboardCheckString">
+        <Decorator ID="Precondition">
             <description>            
-                <p>Executes its child node only if the string value of a given input port is equal to the expected value.</p>
-                <p>If this precondition is met, the child node will be run and this node will return the status returned from the child.</p>
+                <p>Executes its child node only if a condition is met.</p>
+                <p>If the precondition is met, the child node will be run and this node will return the status returned from the child.</p>
                 <p>If the precondition is not met, this node will return the BT::NodeStatus value specified in "return_on_mismatch".</p>
             </description>
-            <input_port name="value_A" default="some_value">First string value to compare.</input_port>
-            <input_port name="value_B" default="some_other_value">Second string value to compare.</input_port>
-            <input_port name="return_on_mismatch" default="SUCCESS">Status to return if value_A and value_B have different values. Can be RUNNING, SUCCESS, or FAILURE.</input_port>
-        </Decorator>     
+            <input_port name="if" default="">If condition</input_port>
+            <input_port name="else" default="SUCCESS">Status to return if condition not met. Can be RUNNING, SUCCESS, or FAILURE.</input_port>
+        </Decorator>
         <Decorator ID="Inverter">
             <description>
                 <p>Tick the child once and return SUCCESS if the child failed or FAILURE if the child succeeded.</p>
@@ -156,6 +155,14 @@
             </description>
             <input_port name="value" default="">Value represented as a string. convertFromString must be implemented.</input_port>
             <inout_port name="output_key" default="">Name of the blackboard entry where the value should be written.</inout_port>
+        </Action>
+        <Action ID="Script">
+            <description>
+                <p>Introduced in BT.CPP 4 to integrate scripting language within XML</p>
+                <p>Allows users to read from and write to variables in the blackboard</p>
+                <p>Can perform operation like assignment, comparison, etc.</p>
+            </description>
+            <input_port name="code" default="">Code that can be parsed.</input_port>
         </Action>
         <SubTree />
     </TreeNodesModel>

--- a/src/picknik_ur_base_config/objectives/tree_nodes_model.xml
+++ b/src/picknik_ur_base_config/objectives/tree_nodes_model.xml
@@ -1,14 +1,52 @@
 <root>
+     <!-- Action nodes -->
     <TreeNodesModel>
-        <Action ID="InitializeMTCTask">
-            <metadata subcategory="MTC"/>
+        <Action ID="GetApriltagPose">
+            <metadata subcategory="Perception"/>
             <description>
                 <p>
-                    Creates a shared pointer to a new MTC Task object, populates it with global settings (for example, the names of controllers to enable by default when executing trajectories planned by this task), and sets it as an output data port.
+                    Provides functions for realtime tracking of AprilTag in published image topics.
+                </p>
+                <p>
+                    Parameters for tag detector are ingested parsed YAML configuration. Raw images are processed from the specified camera stream topic,
+                    and detections are published as a vector of TransformStamped to the specified output topic.
+                </p>
+                <p>
+                    NOTE: This behavior will never terminate on its own. You must wrap it in a sequence that will handle halting the node.
                 </p>
             </description>
-            <input_port name="controller_names" default="/joint_trajectory_controller /robotiq_gripper_controller">List of controller names to use for executing an MTC trajectory.</input_port>
-            <output_port name="task" default="{mtc_task}">MoveIt Task Constructor task.</output_port>
+            <input_port name="parameters" default="{parameters}">Parameters for the apriltag bt node</input_port>
+            <input_port name="camera_stream_topic" default="/wrist_mounted_camera/color/image_raw">Target camera stream topic.</input_port>
+            <input_port name="detection_transform_stamped_topic" default="/apriltag_detections">Output transform stamped topic.</input_port>
+        </Action>
+        <Action ID="ActivateControllers">
+            <description>
+                <p>
+                    Activates a controller whose name is given by the "controller_name" input port.
+                </p>
+            </description>
+            <input_port name="controller_names" default="">The controller to activate.</input_port>
+        </Action>
+        <Action ID="BreakpointSubscriber">
+            <description>
+                <p>
+                    Subscribes to a topic that can be used for pausing an objective during execution to allow introspection. This behavior will listen on the configured topic for a True/False message which will cause it to continue or abort from a breakpoint that is included in an objective.
+                </p>
+            </description>
+            <input_port name="breakpoint_topic" default="/studio_breakpoint">Topic the breakpoint listens to. Can be used to continue executing or halting the program to the breakpoint.</input_port>
+        </Action>
+        <Action ID="CheckCuboidSimilarity">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Check if an input object is similar to another object. Succeeds if the objects are similar within the provided criteria and fails if they are not similar.
+                </p>
+            </description>
+            <input_port name="input_cuboid" default="{object}">Cuboid object to evaluate.</input_port>
+            <input_port name="reference_cuboid" default="{object}">Cuboid object to use as a reference for comparison.</input_port>
+            <input_port name="base_frame" default="world">Fixed frame to use when comparing object poses.</input_port>
+            <input_port name="distance_threshold" default="0.02">Threshold for magnitude difference in centroid position.</input_port>
+            <input_port name="orientation_threshold" default="3.14">Threshold for magnitude of difference in centroid orientation.</input_port>
         </Action>
         <Action ID="ClearSnapshot">
             <metadata subcategory="Perception"/>
@@ -18,6 +56,16 @@
                 </p>
             </description>
         </Action>
+        <Action ID="EditWaypoint">
+            <metadata subcategory="User Input"/>
+            <description>
+                <p>
+                    Uses the "/edit_waypoints service" to save the robot's current state as a new named waypoint or erase an existing waypoint. The name of the waypoint to save or delete is set through the "waypoint_name" behavior parameter. The operation to perform on the waypoint is set through the "waypoint_operation" behavior parameter, which must be set to either "save" or "erase".
+                </p>
+            </description>
+            <input_port name="waypoint_name" default="{waypoint_name}">Name of the waypoint to edit.</input_port>
+            <input_port name="waypoint_operation" default="{waypoint_operation}">Waypoint operation type.</input_port>
+        </Action>
         <Action ID="ExecuteMTCTask">
             <metadata subcategory="MTC"/>
             <description>
@@ -26,6 +74,44 @@
                 </p>
             </description>
             <input_port name="solution" default="{mtc_solution}">MoveIt Task Constructor plan solution.</input_port>
+        </Action>
+        <Action ID="GetClosestObjectToPose">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Given a collection of CollisionObjects, find the one closest to the provided pose.
+                </p>
+            </description>
+            <input_port name="objects" default="{objects}">Vector of moveit_msgs/CollisionObjects.</input_port>
+            <input_port name="pose" default="{pose}">The geometry_msgs/PoseStamped used as the point of reference.</input_port>
+            <input_port name="distance_threshold" default="0.1">Search for objects within this distance in meters relative to the pose.</input_port>
+            <output_port name="closest_object" default="{object}">The object that is closest to the pose.</output_port>
+        </Action>
+        <Action ID="FindSingularCuboids">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Analyze a point cloud to find well-singulated cuboids which supported by a surface.
+                </p>
+            </description>
+            <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
+            <input_port name="point_cloud" default="{point_cloud}">Point cloud used as input for finding cuboids.</input_port>
+            <output_port name="detected_shapes" default="{detected_shapes}">Vector of detected cuboids, represented as moveit_msgs/CollisionObject messages.</output_port>
+        </Action>
+        <Action ID="GetDoorHandle">
+            <metadata advanced="true" subcategory="Perception"/>
+            <description>
+                <p>
+                    Calculates the pose, length, and width of a door handle. By convention, the z-axis of "target_handle_pose" is aligned with the handle's axis of rotation, and the x-axis points along the handle toward the door hinge.
+                </p>
+            </description>
+            <input_port name="handle_pivot_pose" default="{get_door_handle_pose.handle_pivot_pose}">Pose of the door handle pivot point.</input_port>
+            <input_port name="handle_tip_pose" default="{get_door_handle_pose.handle_tip_pose}">Pose of the tip of the door handle.</input_port>
+            <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
+            <input_port name="point_cloud" default="{point_cloud}">Point cloud used as input for finding the door handle.</input_port>
+            <output_port name="target_handle_length" default="{handle_length}">Length of the door handle in meters.</output_port>
+            <output_port name="target_handle_pose" default="{handle_pose}">Pose of the door handle.</output_port>
+            <output_port name="target_handle_z_offset" default="{handle_z_offset}">The door handle height.</output_port>
         </Action>
         <Action ID="GetDrawerAxisFromSelection">
             <metadata advanced="true" subcategory="User Input"/>
@@ -66,6 +152,71 @@
             <output_port name="screw_axis_pose" default="{screw_axis_pose}">Pose of the axis of the screw motion to open a door.</output_port>
             <output_port name="screw_origin_pose" default="{screw_origin_pose}">Pose of the origin of the screw motion to open a door.</output_port>
         </Action>
+        <Action ID="GetLatestTransform">
+            <metadata subcategory="Motion Planning"/>
+            <description>
+                <p>
+                    Gets the latest transform from the robot model root to a frame specified as an input parameter to this behavior.
+                </p>
+            </description>
+            <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
+            <output_port name="transform" default="{transform}">Latest transform between the target and source frames.</output_port>
+        </Action>
+        <Action ID="GetPointCloud">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Captures a point cloud and makes it available on an output port.
+                </p>
+                <p>
+                    Optionally takes a string uuid which can be used to identify the requester, and makes it available on an output port. The parameter is "optional", if it unset then no output will be forwarded. Note: no validation is done on the value of the UUID, so any string is provided (including the empty string) it will be set on the output port.
+                </p>
+            </description>
+            <input_port name="target_point_cloud_topic" default="/wrist_mounted_camera/depth/color/points">Point cloud topic the behavior subscribes to.</input_port>
+            <input_port name="uuid" default="">Optional identifier for the incoming request, can be used for mapping responses</input_port>
+            <output_port name="point_cloud" default="{point_cloud}">Captured point cloud in sensor_msgs::msg::PointCloud2 format.</output_port>
+            <output_port name="point_cloud_uuid" default="{point_cloud_uuid}">Captured point cloud in sensor_msgs::msg::PointCloud2 format.</output_port>
+        </Action>
+        <Action ID="SaveImageToFile">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Saves a single image to a file as soon as it receives a message on the topic. Filename will follow the syntax of IMAGE_TOPIC_image_raw_YYYYMMDD_HHMMSS.png
+                </p>
+            </description>
+            <input_port name="image_topic" default="/scene_camera/color/image_raw">The topic this behaviour subscribes to.</input_port>
+            <input_port name="file_path" default="~/.config/moveit_studio/saved_behavior_data">The full path to save the image in.</input_port>
+        </Action>
+        <Action ID="SavePointCloudToFile">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Save the contents of a point cloud on the blackboard to a pcd file using the pcl::PointXYZRGB point type. Filename will follow the syntax of pointcloud_YYYYMMDD_HHMMSS.pcd
+                </p>
+            </description>
+            <input_port name="point_cloud" default="{point_cloud}">This port expects a sensor_msgs::PointCloud2</input_port>
+            <input_port name="file_path" default="~/.config/moveit_studio/saved_behavior_data">The full path to save the point cloud in.</input_port>
+        </Action>
+        <Action ID="InitializeMTCTask">
+            <metadata subcategory="MTC"/>
+            <description>
+                <p>
+                    Creates a shared pointer to a new MTC Task object, populates it with global settings (for example, the names of controllers to enable by default when executing trajectories planned by this task), and sets it as an output data port.
+                </p>
+            </description>
+            <input_port name="controller_names" default="/joint_trajectory_controller /robotiq_gripper_controller">List of controller names to use for executing an MTC trajectory.</input_port>
+            <output_port name="task" default="{mtc_task}">MoveIt Task Constructor task.</output_port>
+        </Action>
+        <Action ID="IsConstraintSatisfied">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Check if the robot's current state satisfies a kinematic visibility constraint.
+                </p>
+            </description>
+            <input_port name="object" default="{object}">The constraint is satisfied if the camera has an unobstructed view of this object.</input_port>
+            <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
+        </Action>
         <Action ID="IsForceWithinThreshold">
             <metadata subcategory="Motion Planning"/>
             <description>
@@ -74,6 +225,14 @@
                 </p>
             </description>
             <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
+        </Action>
+        <Action ID="IsUserAvailable">
+            <metadata advanced="true" subcategory="User Input"/>
+            <description>
+                <p>
+                    Checks for the presence of a user interface by checking if the "/trajectory_bridge" ROS node exists.
+                </p>
+            </description>
         </Action>
         <Action ID="LoadObjectiveParameters">
             <description>
@@ -94,6 +253,16 @@
             <input_port name="file_path" default="">Path to the .PCD file to load.</input_port>
             <input_port name="frame_id" default="world">Frame ID to set for the loaded point cloud.</input_port>
             <output_port name="point_cloud" default="{point_cloud}">Output point cloud message.</output_port>
+        </Action>
+        <Action ID="ModifyObjectInPlanningScene">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Add a collision object to the planning scene.
+                </p>
+            </description>
+            <input_port name="object" default="{object}">The object to add to the planning scene, represented as a moveit_msgs/CollisionObject.</input_port>
+            <input_port name="apply_planning_scene_service" default="/apply_planning_scene">Name of the service advertised by the MoveIt2 ApplyPlanningScene MoveGroup capability.</input_port>
         </Action>
         <Action ID="MoveGripperAction">
             <metadata subcategory="Grasping"/>
@@ -126,6 +295,25 @@
             <input_port name="task" default="{mtc_task}">MoveIt Task Constructor task.</input_port>
             <output_port name="solution" default="{mtc_solution}">MoveIt Task Constructor plan solution.</output_port>
         </Action>
+        <Action ID="PublishPointCloud">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Publishes a point cloud on a ROS topic (typically used for debugging purposes).
+                </p>
+            </description>
+            <input_port name="point_cloud" default="{point_cloud}">Point cloud in sensor_msgs::msg::PointCloud2 format.</input_port>
+            <input_port name="point_cloud_topic" default="/my_point_cloud">Topic the point cloud is published to.</input_port>
+        </Action>
+        <Action ID="ResetPlanningSceneObjects">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Removes all objects which were added to the planning scene during runtime.
+                </p>
+            </description>
+            <input_port name="apply_planning_scene_service" default="/apply_planning_scene">Name of the service advertised by the MoveIt2 ApplyPlanningScene MoveGroup capability.</input_port>
+        </Action>
         <Action ID="RetrieveWaypoint">
             <metadata subcategory="Motion Planning"/>
             <description>
@@ -135,6 +323,30 @@
             </description>
             <input_port name="waypoint_name" default="{waypoint_name}"/>
             <output_port name="waypoint_joint_state" default="{target_joint_state}"/>
+        </Action>
+        <Action ID="SaveCurrentState">
+            <metadata subcategory="User Input"/>
+            <description>
+                <p>
+                    Use the "/get_planning_scene" service to save the robot's current state.
+                </p>
+            </description>
+            <output_port name="saved_robot_state" default="{robot_state}">Current robot state.</output_port>
+        </Action>
+        <Action ID="SendPointCloudToUI">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Given a point cloud, filter it using MoveIt's settings for that sensor, convert it to ASCII PCD format, and publish it on a topic.
+                </p>
+                <p>
+                    The UUID parameter can be used to track the pointcloud request through to other behaviors, if required. It is an optional input port, and if unset then the published message will have an empty string in its UUID field. Note: no validation is done on the value of the UUID, so any string that is provided (including the empty string) will be set on the output port.
+                </p>
+            </description>
+            <input_port name="point_cloud" default="{point_cloud}">Point cloud in sensor_msgs::msg::PointCloud2 format.</input_port>
+            <input_port name="sensor_name" default="scene_scan_camera">The name of the sensor the point cloud was generated from</input_port>
+            <input_port name="point_cloud_uuid" default="">Optional identifier for the request to be published to the pcd_topic</input_port>
+            <input_port name="pcd_topic" default="/pcd_pointcloud_captures">Topic the pcd formatted point cloud is published to.</input_port>
         </Action>
         <Action ID="SetupMTCAffordanceTemplate">
             <metadata subcategory="MTC"/>
@@ -173,6 +385,17 @@
             <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
             <input_port name="screw_axis_pose" default="{screw_axis_pose}">Pose of the axis of the screw motion.</input_port>
             <input_port name="screw_origin_pose" default="{screw_origin_pose}">Pose of the origin of the screw motion to open the drawer.</input_port>
+            <inout_port name="task" default="{mtc_task}">MoveIt Task Constructor task.</inout_port>
+        </Action>
+        <Action ID="SetupMTCCartesianMoveToJointState">
+            <metadata subcategory="MTC"/>
+            <description>
+                <p>
+                    Given an existing MTC Task object and a joint state, appends MTC stages to describe a cartesian motion plan to that joint state.
+                </p>
+            </description>
+            <input_port name="joint_state" default="{joint_state}">Target joint state.</input_port>
+            <input_port name="planning_group_name" default="manipulator">Name of the MoveIt planning group.</input_port>
             <inout_port name="task" default="{mtc_task}">MoveIt Task Constructor task.</inout_port>
         </Action>
         <Action ID="SetupMTCCurrentState">
@@ -258,6 +481,17 @@
             <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
             <inout_port name="task" default="{mtc_task}">MoveIt Task Constructor task.</inout_port>
         </Action>
+        <Action ID="SetupMTCPickCuboid">
+            <metadata subcategory="MTC"/>
+            <description>
+                <p>
+                    Given an existing MTC Task object and a target object, appends MTC stages to describe a motion plan to approach, grasp and lift the object.
+                </p>
+            </description>
+            <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
+            <input_port name="cuboid_object" default="{object}">Cuboid object to grasp, represented as a moveit_msgs/CollisionObject.</input_port>
+            <inout_port name="task" default="{mtc_task}">MoveIt Task Constructor task.</inout_port>
+        </Action>
         <Action ID="SetupMTCPickObject">
             <metadata subcategory="MTC"/>
             <description>
@@ -267,6 +501,16 @@
             </description>
             <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
             <input_port name="grasp_pose" default="{grasp_pose}">End-effector grasping pose.</input_port>
+            <inout_port name="task" default="{mtc_task}">MoveIt Task Constructor task.</inout_port>
+        </Action>
+        <Action ID="SetupMTCUpdateGroupCollisionRule">
+            <metadata subcategory="MTC"/>
+            <description>
+                <p>
+                    Add an MTC Stage to an MTC Task that modifies the planning scene's Allowed Collision Matrix to permit or forbid collision between a planning scene object and the links of a named robot planning group while planning subsequent Stages.
+                </p>
+            </description>
+            <input_port name="parameters" default="{parameters}">Behavior parameters stored in a common configuration file for the objective.</input_port>
             <inout_port name="task" default="{mtc_task}">MoveIt Task Constructor task.</inout_port>
         </Action>
         <Action ID="SplitMTCSolution">
@@ -293,6 +537,43 @@
             </description>
             <input_port name="controller_name" default="streaming_controller">Name of the controller to use for servoing.</input_port>
         </Action>
+        <Action ID="UpdateAdmittanceController">
+            <metadata subcategory="Motion Planning"/>
+            <description>
+                <p>
+                    Updates parameters for an existing admittance controller.
+                </p>
+            </description>
+            <input_port name="config_file_name" default="">Configuration file name.</input_port>
+        </Action>
+        <Action ID="UpdatePlanningScene">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    DEPRECATED: Use UpdatePlanningSceneService and SendPointCloudToUI instead.
+                </p>
+                <p>
+                    Given a point cloud from the specified sensor, will sanitize the point cloud according to that sensor's params and publish the result to the relevant topic to update the occupancy map. It will also convert the resulting pointcloud to ASCII PCD format and publish it to the specified pcd_topic.
+                </p>
+                <p>
+                    The UUID parameter can be used to track the pointcloud request through to other behaviors, if required. It is an optional input port, and if it unset then the published message will have an empty string in its UUID field. Note: no validation is done on the value of the UUID, so any string is provided (including the empty string) it will be set on the output port.
+                </p>
+            </description>
+            <input_port name="point_cloud" default="{point_cloud}">Point cloud in sensor_msgs::msg::PointCloud2 format.</input_port>
+            <input_port name="sensor_name" default="scene_scan_camera">The name of the sensor the point cloud was generated from</input_port>
+            <input_port name="point_cloud_uuid" default="">Optional identifier for the request to be published to the pcd_topic</input_port>
+            <input_port name="pcd_topic" default="/pcd_pointcloud_captures">Topic the pcd formatted point cloud is published to.</input_port>
+        </Action>
+        <Action ID="UpdatePlanningSceneService">
+            <metadata subcategory="Perception"/>
+            <description>
+                <p>
+                    Updates the planning scene's collision octree using the provided point cloud, and waits until the octree has finished updating.
+                </p>
+            </description>
+            <input_port name="point_cloud" default="{point_cloud}">Point cloud in sensor_msgs::msg::PointCloud2 format.</input_port>
+            <input_port name="point_cloud_service" default="/point_cloud_service">Name of the service advertised by the PointCloudServiceOctomapUpdater MoveIt plugin.</input_port>
+        </Action>
         <Action ID="WaitForDuration">
             <description>
                 <p>
@@ -305,7 +586,7 @@
             <metadata advanced="true" subcategory="User Input"/>
             <description>
                 <p>
-                    Takes a shared pointer to an MTC Solution object via an input data port, and publishes the lowest-cost trajectory in that Solution on MTC's "/solution" introspection topic. Creates a SetBool service server on the "/execute_behavior_solution" topic and waits to receive a request containing data: true before succeeding.
+                    Takes a shared pointer to an MTC Solution object via an input data port, and publishes the lowest-cost trajectory in that Solution on the "/preview_solution" topic. Creates a SetBool service server on the "/execute_behavior_solution" topic and waits to receive a request containing data: true before succeeding.
                 </p>
             </description>
             <input_port name="solution" default="{mtc_solution}">MoveIt Task Constructor plan solution.</input_port>


### PR DESCRIPTION
MoveIt Studio v2.0 bumps to BehaviorTree.CPP v4. There are several port names in the standard nodes model that have been updated.