### PR TITLE
Xacro property for initial_positions_file

### DIFF
--- a/src/picknik_ur_base_config/description/picknik_ur5e.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur5e.xacro
@@ -32,8 +32,11 @@
   <!-- Import environment macros -->
   <xacro:include filename="$(find picknik_accessories)/descriptions/geometry/collision_and_visual/cube_collision_and_visual.urdf.xacro" />
 
-  <!-- initial positions for simulations (Mock Hardware and Gazebo) -->
+  <!-- Initial positions for simulations (Mock Hardware and Gazebo) -->
   <xacro:arg name="initial_positions_file" default="$(find picknik_ur5e_base_config)/config/initial_positions.yaml"/>
+
+  <!-- Convert args to properties for substitution in macros -->
+  <xacro:property name="initial_positions_file" default="$(arg initial_positions_file)"/>
 
   <link name="world" />
   <!-- arm -->


### PR DESCRIPTION
In order to use a `xacro:arg` in another xacro macro, we must convert them to properties.

This change adds the conversion, so it can be used like so:
```
  <xacro:ur_robot
    ...
    initial_positions="${xacro.load_yaml(initial_positions_file)}"
    ...
  </xacro:ur_robot>
```

Note, this property is already set in `picknik_ur_gazebo_config`, so this PR simply matches it