### PR TITLE
Use KDL instead of pick_ik for servo

### DIFF
--- a/src/picknik_ur_base_config/config/base_config.yaml
+++ b/src/picknik_ur_base_config/config/base_config.yaml
@@ -133,7 +133,7 @@ moveit_params:
     path: "config/moveit/sensors_3d.yaml"
   servo_kinematics:
     package: "picknik_ur_base_config"
-    path: "config/moveit/pick_ik_kinematics_servo.yaml"
+    path: "config/moveit/kinematics.yaml"
   joint_limits:
     package: "picknik_ur_base_config"
     path: "config/moveit/joint_limits.yaml"


### PR DESCRIPTION
Shortcut story - https://app.shortcut.com/picknik/story/13467/mock-hardware-when-jog-speed-is-lowered-servoing-jumps-to-strange-uncommanded-poses