### PR TITLE
Ensure we do not launch camera nodes if there are not supported cameras

### DIFF
--- a/src/picknik_ur_base_config/launch/hardware.launch.py
+++ b/src/picknik_ur_base_config/launch/hardware.launch.py
@@ -41,24 +41,27 @@ cameras_config = system_config_parser.get_cameras_config()
 
 
 def generate_launch_description():
-    nodes_to_start = []
-    included_launch_files = []
+    nodes_to_launch = []
 
-    frame_pair_params = [
-        {
-            "world_frame": "world",
-            "camera_frames": generate_camera_frames(cameras_config),
-        }
-    ]
-
-    nodes_to_start.append(
-        Node(
+    # Do not launch any nodes if there are no configured cameras.
+    if not cameras_config:
+        print(
+            "No camera configuration found. Not launching any camera transform nodes."
+        )
+    else:
+        frame_pair_params = [
+            {
+                "world_frame": "world",
+                "camera_frames": generate_camera_frames(cameras_config),
+            }
+        ]
+        camera_transforms_node = Node(
             package="moveit_studio_agent",
             executable="camera_transforms_node",
             name="camera_transforms_node",
             output="screen",
             parameters=frame_pair_params,
         )
-    )
+        nodes_to_launch.append(camera_transforms_node)
 
-    return LaunchDescription(nodes_to_start + included_launch_files)
+    return LaunchDescription(nodes_to_launch)

--- a/src/picknik_ur_base_config/launch/sim/hardware_sim.launch.py
+++ b/src/picknik_ur_base_config/launch/sim/hardware_sim.launch.py
@@ -43,23 +43,27 @@ cameras_config = system_config_parser.get_cameras_config()
 
 
 def generate_launch_description():
-    frame_pair_params = [
-        {
-            "world_frame": "world",
-            "camera_frames": generate_camera_frames(cameras_config),
-        }
-    ]
+    nodes_to_launch = []
 
-    camera_transforms_node = Node(
-        package="moveit_studio_agent",
-        executable="camera_transforms_node",
-        name="camera_transforms_node",
-        output="screen",
-        parameters=frame_pair_params,
-    )
-
-    return LaunchDescription(
-        [
-            camera_transforms_node,
+    # Do not launch any nodes if there are no configured cameras.
+    if not cameras_config:
+        print(
+            "No camera configuration found. Not launching any camera transform nodes."
+        )
+    else:
+        frame_pair_params = [
+            {
+                "world_frame": "world",
+                "camera_frames": generate_camera_frames(cameras_config),
+            }
         ]
-    )
+        camera_transforms_node = Node(
+            package="moveit_studio_agent",
+            executable="camera_transforms_node",
+            name="camera_transforms_node",
+            output="screen",
+            parameters=frame_pair_params,
+        )
+        nodes_to_launch.append(camera_transforms_node)
+
+    return LaunchDescription(nodes_to_launch)


### PR DESCRIPTION
Built in support for "sim" cameras does not exist for mock hardware, so we should not launch the camera transforms node when running in simulation.