### PR TITLE
Add Example Agent call_do_objective.py Scripts

### DIFF
--- a/src/moveit_studio_agent_utils/CMakeLists.txt
+++ b/src/moveit_studio_agent_utils/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(moveit_studio_agent_utils)
+
+find_package(ament_cmake REQUIRED)
+find_package(moveit_studio_agent_msgs REQUIRED)
+find_package(moveit_studio_behavior_interface REQUIRED)
+find_package(moveit_studio_behavior_msgs REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(std_msgs REQUIRED)
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+    moveit_studio_agent_msgs
+    moveit_studio_behavior_interface
+    moveit_studio_behavior_msgs
+    std_msgs
+)
+
+#############
+## Install ##
+#############
+
+# Install scripts directory
+install(PROGRAMS 
+    scripts/call_do_objective.py 
+    scripts/call_do_objective_waypoint.py
+    DESTINATION lib/${PROJECT_NAME}
+)
+
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/moveit_studio_agent_utils/README.md
+++ b/src/moveit_studio_agent_utils/README.md
@@ -1,0 +1,5 @@
+# moveit_studio_agent_utils
+
+Provides Scripts to interact with MoveIt Studio Agent API programatically. 
+
+Please see the [Interact with the Objective Server Directly](https://docs.picknik.ai/en/stable/how_to/interact_with_the_objective_server_directly/interact_with_the_objective_server_directly.html) tutorial for more information on these scripts and their use.

--- a/src/moveit_studio_agent_utils/package.xml
+++ b/src/moveit_studio_agent_utils/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>moveit_studio_agent_utils</name>
+  <version>2.1.0</version>
+  <description>Package containing scripts for interacting with MoveIt Studio Agent</description>
+
+  <maintainer email="chance.cardona@picknik.ai">Chance Cardona</maintainer>
+  <author email="chance.cardona@picknik.ai">Chance Cardona</author>
+
+  <license>BSD-3</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>moveit_common</build_depend>
+
+  <depend>moveit_studio_agent_msgs</depend>
+  <depend>moveit_studio_behavior_interface</depend>
+  <depend>moveit_studio_behavior_msgs</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_clang_format</test_depend>
+  <test_depend>ament_clang_tidy</test_depend>
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>picknik_ament_copyright</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/moveit_studio_agent_utils/scripts/call_do_objective.py
+++ b/src/moveit_studio_agent_utils/scripts/call_do_objective.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 PickNik Inc.
+# All rights reserved.
+#
+# Unauthorized copying of this code base via any medium is strictly prohibited.
+# Proprietary and confidential.
+
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+import sys
+
+from moveit_studio_agent_msgs.action import DoObjectiveSequence
+
+
+class DoObjectiveSequenceClient(Node):
+    def __init__(self):
+        super().__init__("DoObjectiveSequence")
+        self._action_client = ActionClient(self, DoObjectiveSequence, "do_objective")
+
+    def send_goal(self, objective_name):
+        goal_msg = DoObjectiveSequence.Goal()
+        goal_msg.objective_name = objective_name
+        self._action_client.wait_for_server()
+        result = self._action_client.send_goal_async(goal_msg)
+        return result
+
+
+def main(args=None):
+    if len(sys.argv) < 2:
+        print(
+            "usage: ros2 run moveit_studio_behavior call_do_objective.py 'Objective Name'"
+        )
+    else:
+        rclpy.init(args=args)
+
+        client = DoObjectiveSequenceClient()
+
+        future = client.send_goal(sys.argv[1])
+
+        rclpy.spin_until_future_complete(client, future)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/moveit_studio_agent_utils/scripts/call_do_objective_waypoint.py
+++ b/src/moveit_studio_agent_utils/scripts/call_do_objective_waypoint.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 PickNik Inc.
+# All rights reserved.
+#
+# Unauthorized copying of this code base via any medium is strictly prohibited.
+# Proprietary and confidential.
+
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+import sys
+
+from moveit_studio_agent_msgs.action import DoObjectiveSequence
+from moveit_studio_behavior_msgs.msg import BehaviorParameter, BehaviorParameterDescription
+
+class DoObjectiveSequenceClient(Node):
+    def __init__(self):
+        super().__init__("DoObjectiveSequence")
+        self._action_client = ActionClient(self, DoObjectiveSequence, "do_objective")
+
+    def send_goal(self, objective_name, waypoint_name="Behind"):
+        goal_msg = DoObjectiveSequence.Goal()
+        goal_msg.objective_name = objective_name
+
+        behavior_parameter = BehaviorParameter()
+        behavior_parameter.behavior_namespaces.append("move_to_joint_state")
+        behavior_parameter.description.name = "waypoint_name"
+        behavior_parameter.description.type = BehaviorParameterDescription.TYPE_STRING
+        behavior_parameter.string_value = waypoint_name
+        goal_msg.parameter_overrides = [behavior_parameter]
+
+        self._action_client.wait_for_server()
+        result = self._action_client.send_goal_async(goal_msg)
+        return result
+
+
+def main(args=None):
+    if len(sys.argv) < 2:
+        print(
+            "usage: ros2 run moveit_studio_behavior call_do_objective.py 'Objective Name'"
+        )
+    else:
+        rclpy.init(args=args)
+
+        client = DoObjectiveSequenceClient()
+
+        future = client.send_goal(sys.argv[1], sys.argv[2])
+
+        rclpy.spin_until_future_complete(client, future)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/moveit_studio_agent_utils/scripts/call_do_objective_waypoint.py
+++ b/src/moveit_studio_agent_utils/scripts/call_do_objective_waypoint.py
@@ -12,16 +12,19 @@ from rclpy.node import Node
 import sys
 
 from moveit_studio_agent_msgs.action import DoObjectiveSequence
-from moveit_studio_behavior_msgs.msg import BehaviorParameter, BehaviorParameterDescription
+from moveit_studio_behavior_msgs.msg import (
+    BehaviorParameter, 
+    BehaviorParameterDescription,
+)
 
 class DoObjectiveSequenceClient(Node):
     def __init__(self):
         super().__init__("DoObjectiveSequence")
         self._action_client = ActionClient(self, DoObjectiveSequence, "do_objective")
 
-    def send_goal(self, objective_name, waypoint_name="Behind"):
+    def send_goal(self, waypoint_name="Behind"):
         goal_msg = DoObjectiveSequence.Goal()
-        goal_msg.objective_name = objective_name
+        goal_msg.objective_name = "Move to Joint State"
 
         behavior_parameter = BehaviorParameter()
         behavior_parameter.behavior_namespaces.append("move_to_joint_state")
@@ -38,14 +41,14 @@ class DoObjectiveSequenceClient(Node):
 def main(args=None):
     if len(sys.argv) < 2:
         print(
-            "usage: ros2 run moveit_studio_behavior call_do_objective.py 'Objective Name'"
+            "usage: ros2 run moveit_studio_behavior call_do_objective.py 'Waypoint Name'"
         )
     else:
         rclpy.init(args=args)
 
         client = DoObjectiveSequenceClient()
 
-        future = client.send_goal(sys.argv[1], sys.argv[2])
+        future = client.send_goal(sys.argv[1])
 
         rclpy.spin_until_future_complete(client, future)
 


### PR DESCRIPTION
This just adds a barebones package containing the `call_do_objective.py` scripts for interacting with the MoveIt Studio Agent. This is part of the "Create python tutorial for externally triggering and communicating with Objectives" PRD so that we don't need to reference the file inside of the docker container. 

I'm not sure if I could have done the CMakeLists.txt or the package.xml different. Included are a fairly minimal set of dependencies needed for things to run smoothly and that users could add to without it immediately breaking, but it could possibly be more minimal. 