### PR TITLE
Add Waypoint Cycling Objective

### DIFF
--- a/src/picknik_ur_base_config/objectives/cycle_between_waypoints.xml
+++ b/src/picknik_ur_base_config/objectives/cycle_between_waypoints.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+  <root BTCPP_format="4" main_tree_to_execute="Cycle Between Waypoints">
+    <BehaviorTree ID="Cycle Between Waypoints" _description="Cycles between two waypoints until failure">
+        <Decorator ID="KeepRunningUntilFailure">
+            <Control ID="Sequence">
+                <Action ID="MoveToJointState" waypoint_name="Right Corner" planning_group_name="manipulator" controller_names="/joint_trajectory_controller /robotiq_gripper_controller"/>
+                <Action ID="MoveToJointState" waypoint_name="Place" planning_group_name="manipulator" controller_names="/joint_trajectory_controller /robotiq_gripper_controller"/>
+            </Control>
+        </Decorator>
+    </BehaviorTree>
+</root>


### PR DESCRIPTION
# Description
Resolves PickNikRobotics/moveit_studio#3161
This PR adds an objective that makes the arm move between two waypoints until failure.

# Testing
This objective was tested with both the mock hardware and gazebo sim using Studio version 2.1.0.
