### PR TITLE
Update MoveIt Servo parameters

### DIFF
--- a/src/picknik_ur_base_config/config/moveit/ur5e_servo.yaml
+++ b/src/picknik_ur_base_config/config/moveit/ur5e_servo.yaml
@@ -2,6 +2,9 @@
 # Modify all parameters related to servoing here
 ###############################################
 
+# Enable dynamic parameter updates
+enable_parameter_update: true
+
 ## Properties of incoming commands
 command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:

--- a/src/picknik_ur_gazebo_config/config/moveit/ur5e_servo.yaml
+++ b/src/picknik_ur_gazebo_config/config/moveit/ur5e_servo.yaml
@@ -1,7 +1,9 @@
 ###############################################
 # Modify all parameters related to servoing here
 ###############################################
-use_gazebo: true  # Whether the robot is started in a Gazebo simulation environment
+
+# Enable dynamic parameter updates
+enable_parameter_update: true
 
 ## Properties of incoming commands
 command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s


### PR DESCRIPTION
Updates a few params needed for when we move to the latest MoveIt 2 version that has https://github.com/ros-planning/moveit2/pull/2096 in it.

Without `enable_parameter_update: true`, MoveIt Servo will not dynamically change parameters at runtime, which is used by our speed sliders etc.

This can go in right now since the added parameters won't affect the older MoveIt version.