### PR TITLE
Remove dependencies on deprecated UpdatePlanningScene behavior

### DIFF
--- a/src/picknik_ur_base_config/config/moveit/sensors_3d.yaml
+++ b/src/picknik_ur_base_config/config/moveit/sensors_3d.yaml
@@ -16,9 +16,6 @@ scene_scan_camera:
   padding_offset: 0.01
   # The octomap representation will be updated at rate less than or equal to this value.
   max_update_rate: 0.1
-  # This parameter is not required by moveit_studio_plugins/PointCloudServiceOctomapUpdater, but it is needed by the Studio UpdatePlanningScene behavior so we keep it in for now.
-  # TODO(10856): Delete this parameter
-  point_cloud_topic: "/scene_camera/depth/color/points/snapshot"
 
 # Specifies the resolution at which the octomap is maintained (in meters).
 octomap_resolution: 0.01

--- a/src/picknik_ur_base_config/objectives/pick_place_object.xml
+++ b/src/picknik_ur_base_config/objectives/pick_place_object.xml
@@ -20,7 +20,7 @@
                             <!-- Get the latest point cloud from the target topic-->
                             <Action ID="GetPointCloud" topic_name="/wrist_mounted_camera/depth/color/points" message_out="{point_cloud}" />
                             <!-- Publish point cloud for display by UI -->
-                            <Action ID="UpdatePlanningScene" point_cloud="{point_cloud}" sensor_name="scene_scan_camera" pcd_topic="/pcd_pointcloud_captures" point_cloud_uuid=""/>
+                            <Action ID="SendPointCloudToUI" point_cloud="{point_cloud}" sensor_name="scene_scan_camera" pcd_topic="/pcd_pointcloud_captures" point_cloud_uuid=""/>
                             <!-- Detect all cuboids in that point cloud-->
                             <Action ID="FindSingularCuboids" point_cloud="{point_cloud}" parameters="{parameters}" detected_shapes="{cuboids}"/>
                             <!-- Find the closest cuboid to the pose calculated from the user's original click -->

--- a/src/picknik_ur_gazebo_config/config/moveit/sensors_3d.yaml
+++ b/src/picknik_ur_gazebo_config/config/moveit/sensors_3d.yaml
@@ -16,9 +16,6 @@ scene_scan_camera:
   padding_offset: 0.01
   # The octomap representation will be updated at rate less than or equal to this value.
   max_update_rate: 0.1
-  # This parameter is not required by moveit_studio_plugins/PointCloudServiceOctomapUpdater, but it is needed by the Studio UpdatePlanningScene behavior so we keep it in for now.
-  # TODO(10856): Delete this parameter
-  point_cloud_topic: "/scene_camera/depth/color/points/snapshot"
 
 # Specifies the resolution at which the octomap is maintained (in meters).
 octomap_resolution: 0.01


### PR DESCRIPTION
Replace UpdatePlanningScene with SendPointCloudToUI, and remove MoveIt parameters which were only required by UpdatePlanningScene and not used anywhere else.