### PR TITLE
Update Pinch Link

### DIFF
--- a/src/picknik_ur_base_config/config/moveit/picknik_ur5e.srdf
+++ b/src/picknik_ur_base_config/config/moveit/picknik_ur5e.srdf
@@ -59,6 +59,7 @@
     <disable_collisions link1="pinch_link" link2="forearm_link" reason="Adjacent"/>
     <disable_collisions link1="pinch_link" link2="upper_arm_link" reason="Never"/>
     <disable_collisions link1="pinch_link" link2="wrist_1_link" reason="Never"/>
+    <disable_collisions link1="pinch_link" link2="tool_changer_link" reason="Never"/>
     <disable_collisions link1="realsense_camera_adapter_link" link2="robotiq_85_base_link" reason="Never"/>
     <disable_collisions link1="realsense_camera_adapter_link" link2="robotiq_85_left_finger_link" reason="Never"/>
     <disable_collisions link1="realsense_camera_adapter_link" link2="robotiq_85_left_finger_tip_link" reason="Never"/>

--- a/src/picknik_ur_base_config/description/pinch_link.xacro
+++ b/src/picknik_ur_base_config/description/pinch_link.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- radius of wrist_2_link/forearm_link is ~0.045m. Actual offset of this is (radius - attached_link's radius) -->
-  <xacro:macro name="pinch_link" params="prefix:='' connected_to:='forearm_link' length:=0.25 radius:=0.055">
+  <xacro:macro name="pinch_link" params="prefix:='' connected_to:='forearm_link' length:=0.30 radius:=0.055">
     <xacro:property name="prefix_" value='${prefix + "_" if prefix else ""}' />
     <link name="pinch_link">
       <visual>
@@ -24,7 +24,7 @@
     <joint name="${prefix_}pinch_joint" type="fixed">
       <parent link="${connected_to}"/>
       <child link="pinch_link"/>
-      <origin xyz="${-0.09 - length/2} 0 0.0049" rpy="0 ${pi/2} 0" />
+      <origin xyz="${-0.08 - length/2} 0 0.0049" rpy="0 ${pi/2} 0" />
     </joint>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
This PR should resolve https://github.com/PickNikRobotics/moveit_studio/issues/2990. This lengthens the pinch link to avoid the p-stop issues, and adds the tool_changer_link to the excluded collisions as it is not part of UR's driver that causes this p-stop, and not including it causes planning weirdness sometimes. 