### PR TITLE
Update `prefix` argument to `tf_prefix` in UR xacro

### DIFF
--- a/src/moveit_studio_agent_examples/README.md
+++ b/src/moveit_studio_agent_examples/README.md
@@ -2,4 +2,4 @@
 
 Provides Scripts to interact with MoveIt Studio Agent API programmatically. 
 
-Please see the [Interact with the Objective Server Directly](https://docs.picknik.ai/en/latest/how_to/interact_with_the_objective_server_directly/interact_with_the_objective_server_directly.html) tutorial for more information on these scripts and their use.
+Please see the [Interact with the Objective Server Directly](https://docs.picknik.ai/en/stable/how_to/interact_with_the_objective_server_directly/interact_with_the_objective_server_directly.html) tutorial for more information on these scripts and their use.

--- a/src/picknik_ur_base_config/config/control/picknik_ur5e.ros2_control.yaml
+++ b/src/picknik_ur_base_config/config/control/picknik_ur5e.ros2_control.yaml
@@ -20,6 +20,10 @@ controller_manager:
     joint_trajectory_controller_chained_open_door:
       type: joint_trajectory_controller/JointTrajectoryController
 
+io_and_status_controller:
+  ros__parameters:
+    tf_prefix: ""
+
 force_torque_sensor_broadcaster:
   ros__parameters:
     sensor_name: tcp_fts_sensor

--- a/src/picknik_ur_base_config/description/picknik_ur5e.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur5e.xacro
@@ -43,7 +43,7 @@
   <!-- arm -->
   <xacro:ur_robot
     name="$(arg name)"
-    prefix=""
+    tf_prefix=""
     parent="world"
     joint_limits_parameters_file="$(arg joint_limits_parameters_file)"
     kinematics_parameters_file="$(arg kinematics_parameters_file)"

--- a/src/picknik_ur_base_config/package.xml
+++ b/src/picknik_ur_base_config/package.xml
@@ -11,6 +11,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>admittance_controller</exec_depend>
+  <exec_depend>kinematics_interface_kdl</exec_depend>
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_studio_behavior</exec_depend>
@@ -21,7 +23,6 @@
   <exec_depend>robotiq_description</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>ur_robot_driver</exec_depend>
-  <exec_depend>kinematics_interface_kdl</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
+++ b/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
@@ -34,7 +34,7 @@
   <!-- arm -->
   <xacro:ur_robot
     name="$(arg name)"
-    prefix=""
+    tf_prefix=""
     parent="world"
     joint_limits_parameters_file="$(arg joint_limits_parameters_file)"
     kinematics_parameters_file="$(arg kinematics_parameters_file)/$(arg name)/default_kinematics.yaml"


### PR DESCRIPTION
The latest version of the UR description package introduced a breaking change here: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/57, related to ros2_control updates.

This will be needed to upgrade us to the latest ROS 2 Humble versions.