### PR TITLE
Require CMake 3.22

### DIFF
--- a/src/moveit_studio_agent_examples/CMakeLists.txt
+++ b/src/moveit_studio_agent_examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.22)
 project(moveit_studio_agent_examples)
 
 find_package(ament_cmake REQUIRED)

--- a/src/picknik_ur_base_config/CMakeLists.txt
+++ b/src/picknik_ur_base_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.22)
 project(picknik_ur_base_config)
 
 find_package(ament_cmake REQUIRED)

--- a/src/picknik_ur_gazebo_config/CMakeLists.txt
+++ b/src/picknik_ur_gazebo_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.22)
 project(picknik_ur_gazebo_config)
 
 find_package(ament_cmake REQUIRED)

--- a/src/picknik_ur_site_config/CMakeLists.txt
+++ b/src/picknik_ur_site_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.22)
 project(picknik_ur_site_config)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Because we're requiring Ubuntu 22, it makes sense to require the version of CMake that Ubuntu 22 ships. This opts us into a number of new and improved default behaviors that fix various things. See [this page](https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html) for all the new policies we will be opted into.