### PR TITLE
Remove old links, point users to public docs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a sample user workspace for running MoveIt Studio with a generic Universal Robots arm.
 For more information, refer to the [MoveIt Studio Documentation](https://docs.picknik.ai/).
 
-Instructions for building your own MoveIt Studio configuration can be found [here.](https://docs.picknik.ai/en/stable/concepts/config_package/config_package.html)
+Instructions for building your own MoveIt Studio configuration can be found [in the getting started guides.](https://docs.picknik.ai/en/stable/getting_started/getting_started.html)
 
 MoveIt Studio can be used with real robots and full simulators such as Gazebo and NVIDIA Isaac Sim.
 For testing purposes, you can also use the [ROS 2 Control Mock Components](https://control.ros.org/master/doc/ros2_control/hardware_interface/doc/mock_components_userdoc.html), which is what this repo is configured to use.
@@ -24,29 +24,4 @@ MoveIt Studio supports two types of site configuration packages, a base config a
 [Site configs](src/picknik_ur_site_config/README.md) are used to override any parameters of the base configuration, or add additional features or constraints for a particular installation.
 
 This workspace offers a reasonable starting point for those users looking to develop with MoveIt Studio using custom base and site configurations.
-For more information refer to the [online documentation](https://docs.picknik.ai/en/stable/concepts/config_package/config_package.html).
-
-## Beyond site configurations
-
-A custom site configuration is a great jumping off point for starting development with MoveIt Studio.
-
-We recommend reviewing the [online documentation](https://docs.picknik.ai/en/stable/) for more information on building Objectives, implementing custom Behaviors, and integrating peripherals into the MoveIt Studio application.
-
-# Launching a Mock Hardware Robot
-
-**This repository assumes you have followed the [installation instructions online](https://docs.picknik.ai/en/stable/getting_started/software_installation/software_installation.html).**
-If that is the case, follow [these instructions](https://docs.picknik.ai/en/stable/getting_started/configuring_moveit_studio/configuring_moveit_studio.html) for updating and running the configuration provided in this repository.
-
-Otherwise, it is left to the user to ensure that the prerequites from the installation process have been met.
-
-To manually launch MoveIt Studio with the default configuration provided by this workspace, specify this repository as the target `STUDIO_HOST_USER_WORKSPACE` in your MoveIt Studio configuration.
-By default, `STUDIO_HOST_USER_WORKSPACE` points to `$HOME/moveit_studio_ws`.
-If you have cloned this repository to a different location, then update the line to point to this workspace.
-
-Once that is done, from the root of the workspace run:
-
-`docker compose up`
-
-Wait a moment for the application to start, then open the Chrome browser and navigate to ``http://localhost``.
-
-You should be up and running with the default UR5e configuration!
+For more information refer to the [online documentation](https://docs.picknik.ai/en/stable/).

--- a/src/moveit_studio_agent_examples/README.md
+++ b/src/moveit_studio_agent_examples/README.md
@@ -2,4 +2,4 @@
 
 Provides Scripts to interact with MoveIt Studio Agent API programmatically. 
 
-Please see the [Interact with the Objective Server Directly](https://docs.picknik.ai/en/stable/how_to/interact_with_the_objective_server_directly/interact_with_the_objective_server_directly.html) tutorial for more information on these scripts and their use.
+Please see the [getting started guides](https://docs.picknik.ai/en/stable/getting_started/getting_started.html) for more information on these scripts and their use.

--- a/src/picknik_ur_gazebo_config/README.md
+++ b/src/picknik_ur_gazebo_config/README.md
@@ -2,6 +2,4 @@
 
 A MoveIt Studio site configuration for a UR5e simulated in Gazebo, based on the `picknik_ur_base_config` package.
 
-This package follows the required structure described in [Creating a New Site Config Package](https://docs.picknik.ai/en/stable/concepts/config_package/config_package.html#creating-a-new-site-config-package), and may be used to add environments, Behaviors, and Objectives on top of the UR5e base configuration specified in `site_config.yaml`.
-
 For further documentation see: [MoveIt Studio Documentation](https://docs.picknik.ai/)

--- a/src/picknik_ur_site_config/README.md
+++ b/src/picknik_ur_site_config/README.md
@@ -2,6 +2,4 @@
 
 A MoveIt Studio site configuration for a UR5e based on the `picknik_ur_base_config` package.
 
-This package follows the required structure described in [Creating a New Site Config Package](https://docs.picknik.ai/en/stable/concepts/config_package/config_package.html#creating-a-new-site-config-package), and may be used to add environments, Behaviors, and Objectives on top of the UR5e base configuration specified in `site_config.yaml`.
-
 For further documentation see: [MoveIt Studio Documentation](https://docs.picknik.ai/)


### PR DESCRIPTION
After the major public documentation reorg many of these links have gone stale. We should default to the getting started guides to reduce future overhead.