### PR TITLE
Add parameters to toggle camera launching on hardware

### DIFF
--- a/src/picknik_ur_base_config/config/base_config.yaml
+++ b/src/picknik_ur_base_config/config/base_config.yaml
@@ -28,6 +28,12 @@ hardware:
   # [Optional, default=True]
   launch_robot_state_publisher: True
 
+  # If the MoveIt Studio Agent should launch cameras when running on hardware.
+  # This can be set to False if you are testing without cameras, or have your own separate
+  # way to launch cameras.
+  # [Optional, default=True]
+  launch_cameras: True
+
   # If the MoveIt Studio Agent should launch cameras when simulated.
   # This must be False when using mock hardware, since there are no cameras simulated.
   # [Optional, default=True]

--- a/src/picknik_ur_gazebo_config/config/site_config.yaml
+++ b/src/picknik_ur_gazebo_config/config/site_config.yaml
@@ -31,6 +31,9 @@ hardware:
   # This should be false if you are launching the robot state publisher as part of drivers.
   launch_robot_state_publisher: True
 
+  # If the MoveIt Studio Agent should launch cameras when running on hardware.
+  launch_cameras: True
+
   # If the MoveIt Studio Agent should launch cameras when simulated.
   launch_cameras_when_simulated: True
 


### PR DESCRIPTION
This adds the `launch_cameras` parameter to the example config packages in this repo.