### PR TITLE
Camera scene zoomed out and rotated

### DIFF
--- a/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
+++ b/src/picknik_ur_gazebo_config/description/picknik_ur_gazebo.xacro
@@ -98,7 +98,7 @@
   <joint name="external_camera_joint" type="fixed">
     <parent link="world" />
     <child link="external_camera_link" />
-    <origin xyz="0.3 -0.3 1.0" rpy="0.0 0.4 3.14" />
+    <origin xyz="1.1 -1.1 1.3" rpy="0.0 0.4 2.4" />
   </joint>
 
   <xacro:realsense_d435 parent="external_camera_link" name="scene_camera" visible="false" simulate_depth="true">


### PR DESCRIPTION
The camera scene has been zoomed out and rotated to display the whole robot and one wall.

![image](https://github.com/PickNikRobotics/moveit_studio_ws/assets/5970998/4c944c8e-b55c-41ba-8913-533bb6435f35)
