### PR TITLE
Gazebo config: Unfavorite Objectives, tweak favorited Waypoints

### DIFF
--- a/src/picknik_ur_base_config/objectives/push_button.xml
+++ b/src/picknik_ur_base_config/objectives/push_button.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <root BTCPP_format="4" main_tree_to_execute="Push Button">
-    <BehaviorTree ID="Push Button" _description="Push a button with the end effector" _favorite="true">
+    <BehaviorTree ID="Push Button" _description="Push a button with the end effector">
         <Control ID="Sequence">
             <Action ID="LoadObjectiveParameters" config_file_name="push_along_axis_config.yaml" parameters="{parameters}" />
             <SubTree ID="CloseGripper" />

--- a/src/picknik_ur_gazebo_config/objectives/3_waypoint_pick_and_place.xml
+++ b/src/picknik_ur_gazebo_config/objectives/3_waypoint_pick_and_place.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <root BTCPP_format="4" main_tree_to_execute="3 Waypoints Pick and Place">
     <!-- ////////// -->
-    <BehaviorTree ID="3 Waypoints Pick and Place" _description="Repeatedly pick up a small object, place it at desired destination, and then navigate to specified waypoint until failure" _favorite="true">
+    <BehaviorTree ID="3 Waypoints Pick and Place" _description="Repeatedly pick up a small object, place it at desired destination, and then navigate to specified waypoint until failure">
         <Control ID="Sequence">
             <!-- Clear snapshot, move to center pose, and open gripper -->
             <Action ID="ClearSnapshot" />

--- a/src/picknik_ur_gazebo_config/objectives/open_door_affordance.xml
+++ b/src/picknik_ur_gazebo_config/objectives/open_door_affordance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <root BTCPP_format="4" main_tree_to_execute="Open Cabinet Door">
-    <BehaviorTree ID="Open Cabinet Door" _description="Open a cabinet door by grasping and pulling its handle" _favorite="true">
+    <BehaviorTree ID="Open Cabinet Door" _description="Open a cabinet door by grasping and pulling its handle">
         <Control ID="Sequence" name="Setup">
             <Action ID="LoadObjectiveParameters" config_file_name="open_door_affordance_config.yaml" parameters="{parameters}" />
             <Action ID="GetPoseFromUser" parameter_name="process_door_selection.hinge_axis_pose_end" parameter_value="{hinge_axis_pose_end}" />

--- a/src/picknik_ur_gazebo_config/waypoints/waypoints.yaml
+++ b/src/picknik_ur_gazebo_config/waypoints/waypoints.yaml
@@ -49,7 +49,7 @@
     velocity: []
   name: Home
 - description: ''
-  favorite: true
+  favorite: false
   joint_state:
     effort: []
     header:
@@ -74,7 +74,7 @@
     velocity: []
   name: Left Corner
 - description: ''
-  favorite: true
+  favorite: false
   joint_state:
     effort: []
     header:
@@ -99,7 +99,7 @@
     velocity: []
   name: Right Corner
 - description: ''
-  favorite: true
+  favorite: false
   joint_state:
     effort: []
     header:
@@ -298,3 +298,53 @@
       - 2.282092208042741e-05
     velocity: []
   name: Wrist 2 Max
+- description: Move here and run Take Snapshot again!
+  favorite: true
+  joint_state:
+    effort: []
+    header:
+      frame_id: world
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - -1.5113688855545728
+    - -0.849676772994894
+    - -1.7900954114547076
+    - -0.6712599508612579
+    - 1.6807113853283657
+    - -0.010627009718118157
+    velocity: []
+  name: Right Wall
+- description: ''
+  favorite: true
+  joint_state:
+    effort: []
+    header:
+      frame_id: world
+      stamp:
+        nanosec: 0
+        sec: 0
+    name:
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+    position:
+    - 0.0003205429823013286
+    - -0.3419419371606998
+    - -0.5134107235570269
+    - -2.3994585463037112
+    - 1.6501763241696035
+    - 3.878003640148636e-05
+    velocity: []
+  name: Monitor View

--- a/src/picknik_ur_gazebo_config/waypoints/waypoints.yaml
+++ b/src/picknik_ur_gazebo_config/waypoints/waypoints.yaml
@@ -308,19 +308,19 @@
         nanosec: 0
         sec: 0
     name:
-    - shoulder_pan_joint
-    - shoulder_lift_joint
-    - elbow_joint
-    - wrist_1_joint
-    - wrist_2_joint
-    - wrist_3_joint
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint
     position:
-    - -1.5113688855545728
-    - -0.849676772994894
-    - -1.7900954114547076
-    - -0.6712599508612579
-    - 1.6807113853283657
-    - -0.010627009718118157
+      - -1.5113688855545728
+      - -0.849676772994894
+      - -1.7900954114547076
+      - -0.6712599508612579
+      - 1.6807113853283657
+      - -0.010627009718118157
     velocity: []
   name: Right Wall
 - description: ''
@@ -333,18 +333,18 @@
         nanosec: 0
         sec: 0
     name:
-    - shoulder_pan_joint
-    - shoulder_lift_joint
-    - elbow_joint
-    - wrist_1_joint
-    - wrist_2_joint
-    - wrist_3_joint
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint
     position:
-    - 0.0003205429823013286
-    - -0.3419419371606998
-    - -0.5134107235570269
-    - -2.3994585463037112
-    - 1.6501763241696035
-    - 3.878003640148636e-05
+      - 0.0003205429823013286
+      - -0.3419419371606998
+      - -0.5134107235570269
+      - -2.3994585463037112
+      - 1.6501763241696035
+      - 3.878003640148636e-05
     velocity: []
   name: Monitor View


### PR DESCRIPTION
Got to poking around configs to learn more about the structure and did some tweaks of files in the picknik_ur_gazebo_config config.

Unfavorite objectives sales team should not run:
- Push Button (unreliable)
- Open Cabinet Door (will not work)
- 3 Waypoints Pick and Place (should use Looping PnP instead)

Add some interesting Waypoints:
- Right Wall
- Monitor View

Unfavorite less interesting/redundant waypoints:
- Forward Down
- Left Corner
- Right Corner