### PR TITLE
Add missing dependency on moveit_planners_stomp package

### DIFF
--- a/src/picknik_ur_base_config/package.xml
+++ b/src/picknik_ur_base_config/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>admittance_controller</exec_depend>
   <exec_depend>kinematics_interface_kdl</exec_depend>
+  <exec_depend>moveit_planners_stomp</exec_depend>
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>moveit_studio_agent</exec_depend>
   <exec_depend>moveit_studio_behavior</exec_depend>


### PR DESCRIPTION
`picknik_ur_base_config` loads the `StompPlanner` plugin as one of the available motion planning pipelines, so it needs to have an `exec_depend` on `moveit_planners_stomp`.

I think this only causes problems for the rare user who is building the entire underlay workspace from source (i.e., me), since the Studio Docker image builds all packages in the MoveIt2 repo every time regardless of which overlay packages depend on them.