### PR TITLE
Fix offset between CNC mesh and CNC collision mesh

### DIFF
--- a/src/picknik_ur_mock_hw_config/description/picknik_ur_machine_tending.xacro
+++ b/src/picknik_ur_mock_hw_config/description/picknik_ur_machine_tending.xacro
@@ -104,7 +104,7 @@
     </visual> 
     <!-- CNC base collision -->
     <collision>
-      <origin xyz="0 0.1 0" rpy="0 0 0"/>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
         <mesh filename="file://$(find picknik_ur_mock_hw_config)/meshes/cnc-collision.dae" scale="1 1 1"/>
       </geometry>


### PR DESCRIPTION
The arm was moving through the front of CNC since the collision mesh was off.

Before 
![image](https://github.com/PickNikRobotics/moveit_studio_ws/assets/17363793/ac8cf3b1-ff07-4e0c-bc6a-61441d0669f8)

After
![image](https://github.com/PickNikRobotics/moveit_studio_ws/assets/17363793/85dd9a93-390a-429b-bd1d-844401f11e73)
