### PR TITLE
Add use_all_planners port to SetupMTCMoveToPose behavior in XML

### DIFF
--- a/src/picknik_ur_base_config/objectives/move_to_pose.xml
+++ b/src/picknik_ur_base_config/objectives/move_to_pose.xml
@@ -5,7 +5,7 @@
             <Action ID="InitializeMTCTask" task_id="move_to_pose" controller_names="/joint_trajectory_controller" task="{move_to_pose_task}"/>
             <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}"/>
             <Action ID="GetPoseFromUser" parameter_name="move_to_pose.target_pose" parameter_value="{target_pose}" />
-            <Action ID="SetupMTCMoveToPose" ik_frame="manual_grasp_link" planning_group_name="manipulator" target_pose="{target_pose}" task="{move_to_pose_task}"/>
+            <Action ID="SetupMTCMoveToPose" ik_frame="manual_grasp_link" planning_group_name="manipulator" target_pose="{target_pose}" task="{move_to_pose_task}" use_all_planners="false"/>
             <Action ID="PlanMTCTask" solution="{move_to_pose_solution}" task="{move_to_pose_task}"/>
             <Fallback name="wait_for_approval_if_user_available">
                 <Inverter>

--- a/src/picknik_ur_site_config/objectives/close_cabinet_door.xml
+++ b/src/picknik_ur_site_config/objectives/close_cabinet_door.xml
@@ -9,7 +9,7 @@
                 <Action ID="InitializeMTCTask" task_id="close_cabinet_door" controller_names="/joint_trajectory_controller" task="{close_cabinet_door_task}"/>
                 <Action ID="SetupMTCCurrentState" task="{close_cabinet_door_task}"/>
                 <Action ID="GetPoseFromUser" parameter_name="close_cabinet_door.target_pose" parameter_value="{target_pose}" />
-                <Action ID="SetupMTCMoveToPose" ik_frame="manual_grasp_link" planning_group_name="manipulator" target_pose="{target_pose}" task="{close_cabinet_door_task}"/>
+                <Action ID="SetupMTCMoveToPose" ik_frame="manual_grasp_link" planning_group_name="manipulator" target_pose="{target_pose}" task="{close_cabinet_door_task}" use_all_planners="false"/>
                 <Action ID="SetupMTCUpdateGroupCollisionRule" name="AllowGripperCollisionWithOctomap" parameters="{parameters}" task="{close_cabinet_door_task}" />
                 <Action ID="SetupMTCMoveAlongFrameAxis" axis="z" max_distance="1.5" min_distance="0.05" parameters="{parameters}" task="{close_cabinet_door_task}" />
                 <Action ID="SetupMTCUpdateGroupCollisionRule" name="ForbidGripperCollisionWithOctomap" parameters="{parameters}" task="{close_cabinet_door_task}" />

--- a/src/picknik_ur_site_config/objectives/inspect_surface.xml
+++ b/src/picknik_ur_site_config/objectives/inspect_surface.xml
@@ -5,7 +5,7 @@
             <Action ID="InitializeMTCTask" task_id="inspect_surface" controller_names="/joint_trajectory_controller" task="{move_to_pose_task}"/>
             <Action ID="SetupMTCCurrentState" task="{move_to_pose_task}"/>
             <Action ID="GetPoseFromUser" parameter_name="inspect_surface.target_pose" parameter_value="{target_pose}" />
-            <Action ID="SetupMTCMoveToPose" ik_frame="manual_grasp_link" planning_group_name="manipulator" target_pose="{target_pose}" task="{move_to_pose_task}"/>
+            <Action ID="SetupMTCMoveToPose" ik_frame="manual_grasp_link" planning_group_name="manipulator" target_pose="{target_pose}" task="{move_to_pose_task}" use_all_planners="false"/>
             <Action ID="PlanMTCTask" solution="{move_to_pose_solution}" task="{move_to_pose_task}"/>
             <Fallback name="wait_for_approval_if_user_available">
                 <Inverter>

--- a/src/picknik_ur_site_config/objectives/push_button.xml
+++ b/src/picknik_ur_site_config/objectives/push_button.xml
@@ -9,7 +9,7 @@
                 <Action ID="InitializeMTCTask" task_id="push_button" controller_names="/joint_trajectory_controller" task="{push_button_task}"/>
                 <Action ID="SetupMTCCurrentState" task="{push_button_task}"/>
                 <Action ID="GetPoseFromUser" parameter_name="push_button.target_pose" parameter_value="{target_pose}" />
-                <Action ID="SetupMTCMoveToPose" ik_frame="manual_grasp_link" planning_group_name="manipulator" target_pose="{target_pose}" task="{push_button_task}"/>
+                <Action ID="SetupMTCMoveToPose" ik_frame="manual_grasp_link" planning_group_name="manipulator" target_pose="{target_pose}" task="{push_button_task}" use_all_planners="false"/>
                 <Action ID="SetupMTCUpdateGroupCollisionRule" name="AllowGripperCollisionWithOctomap" parameters="{parameters}" task="{push_button_task}" />
                 <Action ID="SetupMTCMoveAlongFrameAxis" axis="z" max_distance="0.2" min_distance="0.05" parameters="{parameters}" task="{push_button_task}" />
                 <Action ID="SetupMTCUpdateGroupCollisionRule" name="ForbidGripperCollisionWithOctomap" parameters="{parameters}" task="{push_button_task}" />

--- a/src/picknik_ur_site_config/objectives/push_button_ml.xml
+++ b/src/picknik_ur_site_config/objectives/push_button_ml.xml
@@ -42,7 +42,7 @@
                 <Action ID="SetupMTCCurrentState" task="{push_along_axis_task}" />
                 <Action ID="SetupMTCMoveToPose" ik_frame="manual_grasp_link"
                     planning_group_name="manipulator" target_pose="{button_pose}"
-                    task="{push_along_axis_task}" />
+                    task="{push_along_axis_task}" use_all_planners="false"/>
                 <Action ID="SetupMTCUpdateGroupCollisionRule"
                     name="AllowGripperCollisionWithOctomap" parameters="{parameters}"
                     task="{push_along_axis_task}" />


### PR DESCRIPTION
This change removes the following warning from the UI
![image](https://github.com/PickNikRobotics/moveit_studio_ws/assets/17363793/2b41a20f-1ee9-42ef-a8b7-ba93a2d38fd4)
