### PR TITLE
Set constraint's z tolerance to 3.14 in my_constraints.yaml

### DIFF
--- a/src/picknik_ur_mock_hw_config/objectives/my_constraints.yaml
+++ b/src/picknik_ur_mock_hw_config/objectives/my_constraints.yaml
@@ -8,4 +8,4 @@ AppendOrientationConstraint:
   tolerance:    # radians
     x: 0.1
     y: 0.1
-    z: 10.0
+    z: 3.14


### PR DESCRIPTION
While playing with the constraints UI editor, I noticed that it doesn't allow for values greater than or less to pi. I've updated the z tolerance on the `my_constraints.yaml` file (used by the `Constrained Pick and Place Objective`) to be `3.14` to reflect this (having a value greater than pi means this value gets truncated to pi anyways in this context).