### PR TITLE
remove the manual_grasp_link offset

### DIFF
--- a/src/picknik_ur_base_config/description/picknik_ur.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur.xacro
@@ -97,7 +97,7 @@
   <joint name="manual_grasp_joint" type="fixed">
     <parent link="grasp_link" />
     <child link="manual_grasp_link" />
-    <origin xyz="0 0 0" rpy="${pi / 180.0 * 5} 0 0" />
+    <origin xyz="0 0 0" rpy="0 0 0" />
   </joint>
 
   <!-- Environment -->

--- a/src/picknik_ur_mock_hw_config/description/picknik_ur_machine_tending.xacro
+++ b/src/picknik_ur_mock_hw_config/description/picknik_ur_machine_tending.xacro
@@ -92,7 +92,7 @@
   <joint name="manual_grasp_joint" type="fixed">
     <parent link="grasp_link" />
     <child link="manual_grasp_link" />
-    <origin xyz="0 0 0" rpy="${pi / 180.0 * 5} 0 0" />
+    <origin xyz="0 0 0" rpy="0 0 0" />
   </joint>
 
   <!-- CNC machine -->


### PR DESCRIPTION
This change fixes https://github.com/PickNikRobotics/moveit_studio/issues/4543 by removing an offset of 5 degrees that existed in the xacro file.
I have noticed that other scenes have this offset too, but I'm not familiar with those scenes and whether the offset is needed for those, so fixing it in the default `picknik_ur_mock_hw_config` scene for now.