### PR TITLE
Remove the frontend-agent service and option

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,11 +44,6 @@ services:
         delay: 2s
     command: agent_bridge.app
 
-  # Starts the frontend-agent
-  frontend_agent:
-    extends: base
-    command: /usr/lib/formant/agent/formant-agent
-
   # Starts the REST API for the Web UI
   rest_api:
     extends: base

--- a/src/picknik_ur_base_config/config/config.yaml
+++ b/src/picknik_ur_base_config/config/config.yaml
@@ -111,10 +111,7 @@ ros_global_params:
 
 # Configure additional, optional features in MoveIt Studio.
 # [Optional]
-optional_feature_params:
-  # Whether or not to use the Formant bridge for over-the-internet comms.
-  # [Optional, default=False]
-  use_formant_bridge: False
+optional_feature_params: []
 
 # Configuration files for MoveIt.
 # For more information, refer to https://moveit.picknik.ai/humble/doc/examples/examples.html#configuration

--- a/src/picknik_ur_base_config/config/config.yaml
+++ b/src/picknik_ur_base_config/config/config.yaml
@@ -111,7 +111,7 @@ ros_global_params:
 
 # Configure additional, optional features in MoveIt Studio.
 # [Optional]
-optional_feature_params: []
+optional_feature_params: {}
 
 # Configuration files for MoveIt.
 # For more information, refer to https://moveit.picknik.ai/humble/doc/examples/examples.html#configuration


### PR DESCRIPTION
We are not currently using it out of the box, so removing it to reduce our service count and confusion in the config.yaml.