### PR TITLE
Add TRAC_IK configuration

### DIFF
--- a/src/picknik_ur_base_config/config/config.yaml
+++ b/src/picknik_ur_base_config/config/config.yaml
@@ -139,7 +139,7 @@ moveit_params:
     path: "config/moveit/sensors_3d.yaml"
   servo_kinematics:
     package: "picknik_ur_base_config"
-    path: "config/moveit/trac_ik_kinematics_distance.yaml"
+    path: "config/moveit/trac_ik_kinematics_speed.yaml"
   joint_limits:
     package: "picknik_ur_base_config"
     path: "config/moveit/joint_limits.yaml"

--- a/src/picknik_ur_base_config/config/config.yaml
+++ b/src/picknik_ur_base_config/config/config.yaml
@@ -130,7 +130,7 @@ moveit_params:
     path: "config/moveit/stomp_planning.yaml"
   kinematics:
     package: "picknik_ur_base_config"
-    path: "config/moveit/pick_ik_kinematics.yaml"
+    path: "config/moveit/trac_ik_kinematics_distance.yaml"
   servo:
     package: "picknik_ur_base_config"
     path: "config/moveit/ur_servo.yaml"
@@ -139,7 +139,7 @@ moveit_params:
     path: "config/moveit/sensors_3d.yaml"
   servo_kinematics:
     package: "picknik_ur_base_config"
-    path: "config/moveit/kinematics.yaml"
+    path: "config/moveit/trac_ik_kinematics_distance.yaml"
   joint_limits:
     package: "picknik_ur_base_config"
     path: "config/moveit/joint_limits.yaml"

--- a/src/picknik_ur_base_config/config/moveit/trac_ik_kinematics_distance.yaml
+++ b/src/picknik_ur_base_config/config/moveit/trac_ik_kinematics_distance.yaml
@@ -1,0 +1,6 @@
+manipulator:
+  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3
+  epsilon: 0.0001
+  solve_type: "Distance"

--- a/src/picknik_ur_base_config/config/moveit/trac_ik_kinematics_speed.yaml
+++ b/src/picknik_ur_base_config/config/moveit/trac_ik_kinematics_speed.yaml
@@ -1,0 +1,6 @@
+manipulator:
+  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3
+  epsilon: 0.0001
+  solve_type: "Speed"

--- a/src/picknik_ur_base_config/package.xml
+++ b/src/picknik_ur_base_config/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>picknik_accessories</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>robotiq_description</exec_depend>
+  <exec_depend>trac_ik_kinematics_plugin</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>ur_robot_driver</exec_depend>
 


### PR DESCRIPTION
This PR adds the TRAC_IK solver as the default configuration for both planning and servoing.