### PR TITLE
docker-compose.yaml:  Increase rest_api container timeout

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
     healthcheck:
       test: "curl -f http://localhost:3200/objectives"
       interval: 5s
-      timeout: 1m
+      timeout: 3m
     command: rest_api.app
 
   # Starts the robot drivers


### PR DESCRIPTION
The rest_api container health check took longer than the 1m timeout to start passing on a lightly loaded 2022 ThinkPad Carbon X1 running Ubuntu, and MoveIt Studio refused to start.

Studio v. 2.4.0 worked fine; IIRC this problem started in v. 2.5.0.