### PR TITLE
Remove Gibson behavior plugin loader

### DIFF
--- a/src/picknik_ur_site_config/config/config.yaml
+++ b/src/picknik_ur_site_config/config/config.yaml
@@ -9,8 +9,6 @@ objectives:
   behavior_loader_plugins:
     visual_servo_behaviors:
       - "moveit_visual_servo::behaviors::VisualServoBehaviorLoader"
-    gibson:
-      - "gibson_behavior::GibsonBehaviorsLoader"
   objective_library_paths:
     # You must use a unique key for each package.
     # The picknik_ur_base_config uses "core"


### PR DESCRIPTION
This is going away in favor of more core-to-Studio ML behaviors.