### PR TITLE
Fix pick and place object objective in gazebo

### DIFF
--- a/src/picknik_ur_gazebo_config/objectives/pick_place_object_config.yaml
+++ b/src/picknik_ur_gazebo_config/objectives/pick_place_object_config.yaml
@@ -22,7 +22,7 @@ FindSingularCuboids:
   crop_box_size_y: 0.75
   crop_box_size_z: 0.5
 
-SetupMTCPickApproachGrasp:
+SetupMTCApproachGrasp:
   world_frame_name: "world"
   arm_group_name: "manipulator"
   end_effector_group_name: "gripper"


### PR DESCRIPTION
The `Pick and Place Object` currently fails with the gazebo config with the following error
```
[objective_server_node_main-6] [ERROR] [1699247731.778542041] [Logger]: Behavior: SetupMTCApproachGrasp. Error: Could not find behavior specific parameters in the configuration file: Parameter 'SetupMTCApproachGrasp' not found.

```