### PR TITLE
Add comment for `moveit_params.joint_group_name` config parameter

### DIFF
--- a/src/picknik_ur_base_config/config/config.yaml
+++ b/src/picknik_ur_base_config/config/config.yaml
@@ -117,9 +117,10 @@ optional_feature_params:
   use_formant_bridge: False
 
 # Configuration files for MoveIt.
-# For more information, refer to https://moveit.picknik.ai/humble/doc/examples/examples.html#configuration
+# For more information, refer to https://moveit.picknik.ai/main/doc/how_to_guides/moveit_configuration/moveit_configuration_tutorial.html
 # [Required]
 moveit_params:
+  # Used by the Waypoint Manager to save joint states from this joint group.
   joint_group_name: "manipulator"
 
   ompl_planning:


### PR DESCRIPTION
This adds a comment to the `moveit_params.joint_group_name` config parameter to explain that it's used for waypoint saving.

Also updates another doc link.