### PR TITLE
Update paths for our 2f_85 gripper URDF

### DIFF
--- a/src/picknik_ur_base_config/description/robotiq_2f_85_gripper.urdf
+++ b/src/picknik_ur_base_config/description/robotiq_2f_85_gripper.urdf
@@ -229,13 +229,13 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/ur_to_robotiq_adapter.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/ur_to_robotiq_adapter.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/ur_to_robotiq_adapter.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/ur_to_robotiq_adapter.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -254,12 +254,12 @@
   <link name="robotiq_85_base_link">
     <visual>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/robotiq_base.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/robotiq_base.dae"/>
       </geometry>
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/robotiq_base.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/robotiq_base.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -271,12 +271,12 @@
   <link name="robotiq_85_left_knuckle_link">
     <visual>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/left_knuckle.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/left_knuckle.dae"/>
       </geometry>
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/left_knuckle.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/left_knuckle.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -288,12 +288,12 @@
   <link name="robotiq_85_right_knuckle_link">
     <visual>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/right_knuckle.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/right_knuckle.dae"/>
       </geometry>
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/right_knuckle.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/right_knuckle.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -305,12 +305,12 @@
   <link name="robotiq_85_left_finger_link">
     <visual>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/left_finger.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/left_finger.dae"/>
       </geometry>
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/left_finger.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/left_finger.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -322,12 +322,12 @@
   <link name="robotiq_85_right_finger_link">
     <visual>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/right_finger.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/right_finger.dae"/>
       </geometry>
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/right_finger.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/right_finger.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -339,12 +339,12 @@
   <link name="robotiq_85_left_inner_knuckle_link">
     <visual>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/left_inner_knuckle.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/left_inner_knuckle.dae"/>
       </geometry>
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/left_inner_knuckle.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/left_inner_knuckle.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -356,12 +356,12 @@
   <link name="robotiq_85_right_inner_knuckle_link">
     <visual>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/right_inner_knuckle.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/right_inner_knuckle.dae"/>
       </geometry>
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/right_inner_knuckle.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/right_inner_knuckle.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -373,12 +373,12 @@
   <link name="robotiq_85_left_finger_tip_link">
     <visual>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/left_finger_tip.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/left_finger_tip.dae"/>
       </geometry>
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/left_finger_tip.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/left_finger_tip.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -390,12 +390,12 @@
   <link name="robotiq_85_right_finger_tip_link">
     <visual>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/visual/right_finger_tip.dae"/>
+        <mesh filename="package://robotiq_description/meshes/visual/2f_85/right_finger_tip.dae"/>
       </geometry>
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://robotiq_description/meshes/collision/right_finger_tip.stl"/>
+        <mesh filename="package://robotiq_description/meshes/collision/2f_85/right_finger_tip.stl"/>
       </geometry>
     </collision>
     <inertial>


### PR DESCRIPTION
These were updated in: https://github.com/PickNikRobotics/ros2_robotiq_gripper/commit/8e4025879957a7568afd870c1063010464bd3249
, but not in our gripper URDF.

Needed for properly rendering grasp previews:

<img width="1095" alt="image" src="https://github.com/PickNikRobotics/moveit_studio_ws/assets/7966037/08741b8c-c57d-4b1d-be93-a8019c397337">
