### PR TITLE
Remove servo params no longer needed

### DIFF
--- a/src/picknik_ur_base_config/config/moveit/ur_servo.yaml
+++ b/src/picknik_ur_base_config/config/moveit/ur_servo.yaml
@@ -36,12 +36,7 @@ low_pass_filter_coeff: 1.5  # Larger --> trust the filtered data more, trust the
 
 ## MoveIt properties
 move_group_name: manipulator  # Often 'manipulator' or 'arm'
-planning_frame: base_link  # The MoveIt planning frame. Often 'base_link' or 'world'
 is_primary_planning_scene_monitor: false  # The MoveGroup node maintains the planning scene, so Servo needs to get its world info from there.
-
-## Other frames
-ee_frame: manual_grasp_link  # The name of the end effector link, used to return the EE pose
-robot_link_command_frame: base_link  # commands must be given in the frame of a robot link. Usually either the base or end effector
 
 ## Stopping behaviour
 incoming_command_timeout: 0.1  # Stop servoing if X seconds elapse without a new command

--- a/src/picknik_ur_gazebo_config/config/moveit/ur_servo.yaml
+++ b/src/picknik_ur_gazebo_config/config/moveit/ur_servo.yaml
@@ -36,12 +36,7 @@ low_pass_filter_coeff: 4.0  # Larger --> trust the filtered data more, trust the
 
 ## MoveIt properties
 move_group_name: manipulator  # Often 'manipulator' or 'arm'
-planning_frame: base_link  # The MoveIt planning frame. Often 'base_link' or 'world'
 is_primary_planning_scene_monitor: false  # The MoveGroup node maintains the planning scene, so Servo needs to get its world info from there.
-
-## Other frames
-ee_frame: manual_grasp_link  # The name of the end effector link, used to return the EE pose
-robot_link_command_frame: base_link  # commands must be given in the frame of a robot link. Usually either the base or end effector
 
 ## Stopping behaviour
 incoming_command_timeout: 0.05  # Stop servoing if X seconds elapse without a new command

--- a/src/picknik_ur_mock_hw_config/config/moveit/ur_servo.yaml
+++ b/src/picknik_ur_mock_hw_config/config/moveit/ur_servo.yaml
@@ -34,12 +34,7 @@ low_pass_filter_coeff: 1.5  # Larger --> trust the filtered data more, trust the
 
 ## MoveIt properties
 move_group_name: manipulator  # Often 'manipulator' or 'arm'
-planning_frame: base_link  # The MoveIt planning frame. Often 'base_link' or 'world'
 is_primary_planning_scene_monitor: false  # The MoveGroup node maintains the planning scene, so Servo needs to get its world info from there.
-
-## Other frames
-ee_frame: manual_grasp_link  # The name of the end effector link, used to return the EE pose
-robot_link_command_frame: base_link  # commands must be given in the frame of a robot link. Usually either the base or end effector
 
 ## Stopping behaviour
 incoming_command_timeout: 0.1  # Stop servoing if X seconds elapse without a new command


### PR DESCRIPTION
Another change regarding the removal of Servo's `ee_frame` and `planning_frame`. This one removes the no-longer-needed params from the base configs.