### PR TITLE
Use public URLs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src/external_dependencies/ros2_robotiq_gripper"]
 	path = src/external_dependencies/ros2_robotiq_gripper
-	url = git@github.com:PickNikRobotics/ros2_robotiq_gripper.git
+	url = https://github.com/PickNikRobotics/ros2_robotiq_gripper.git
 [submodule "src/external_dependencies/picknik_accessories"]
 	path = src/external_dependencies/picknik_accessories
-	url = git@github.com:PickNikRobotics/picknik_accessories.git
+	url = https://github.com/PickNikRobotics/picknik_accessories.git
 	branch = ur-main


### PR DESCRIPTION
So that users do not require authentication to clone.