### PR TITLE
Add submodule to tyler's ros2 serial branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 	path = src/external_dependencies/picknik_accessories
 	url = https://github.com/PickNikRobotics/picknik_accessories.git
 	branch = ur-main
+[submodule "src/external_dependencies/serial"]
+	path = src/external_dependencies/serial
+	url = https://github.com/tylerjw/serial.git
+	branch = ros2


### PR DESCRIPTION
- This is transitive dependency and required to build in CI
- related to moving the integration tests into public workspace PickNikRobotics/moveit_studio#4651