### PR TITLE
Remove Legacy Parameters for Configuration Packages

### DIFF
--- a/src/picknik_ur_base_config/config/config.yaml
+++ b/src/picknik_ur_base_config/config/config.yaml
@@ -160,14 +160,6 @@ moveit_params:
     allowed_goal_duration_margin: 5.0
     allowed_start_tolerance: 0.01
 
-# Additional configurable parameters for the MoveIt Studio user interface.
-# [Required]
-ui_params:
-  # By default, MoveIt Studio uses a frame called "manual_grasp_link" for tool grasp pose rendering
-  # and planning.
-  # [Required]
-  servo_endpoint_frame_id: "manual_grasp_link"
-
 # Configuration for launching ros2_control processes.
 # [Required, if using ros2_control]
 ros2_control:

--- a/src/picknik_ur_base_config/config/moveit/ur_servo.yaml
+++ b/src/picknik_ur_base_config/config/moveit/ur_servo.yaml
@@ -2,9 +2,6 @@
 # Modify all parameters related to servoing here
 ###############################################
 
-# Enable dynamic parameter updates
-enable_parameter_update: true
-
 ## Properties of incoming commands
 command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
@@ -32,7 +29,6 @@ publish_joint_accelerations: false
 ## Plugins for smoothing outgoing commands
 use_smoothing: true
 smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
-low_pass_filter_coeff: 1.5  # Larger --> trust the filtered data more, trust the measurements less.
 
 ## MoveIt properties
 move_group_name: manipulator  # Often 'manipulator' or 'arm'

--- a/src/picknik_ur_gazebo_config/config/moveit/ur_servo.yaml
+++ b/src/picknik_ur_gazebo_config/config/moveit/ur_servo.yaml
@@ -2,9 +2,6 @@
 # Modify all parameters related to servoing here
 ###############################################
 
-# Enable dynamic parameter updates
-enable_parameter_update: true
-
 ## Properties of incoming commands
 command_in_type: "unitless" # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
@@ -32,7 +29,6 @@ publish_joint_accelerations: false
 ## Plugins for smoothing outgoing commands
 use_smoothing: true
 smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
-low_pass_filter_coeff: 4.0  # Larger --> trust the filtered data more, trust the measurements less.
 
 ## MoveIt properties
 move_group_name: manipulator  # Often 'manipulator' or 'arm'

--- a/src/picknik_ur_mock_hw_config/config/moveit/ur_servo.yaml
+++ b/src/picknik_ur_mock_hw_config/config/moveit/ur_servo.yaml
@@ -1,6 +1,3 @@
-# Enable dynamic parameter updates
-enable_parameter_update: true
-
 ## Properties of incoming commands
 command_in_type: "unitless"  # "unitless"> in the range [-1:1], as if from joystick. "speed_units"> cmds are in m/s and rad/s
 scale:
@@ -27,10 +24,8 @@ publish_joint_velocities: false
 publish_joint_accelerations: false
 
 ## Plugins for smoothing outgoing commands
+use_smoothing: true
 smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
-
-## Incoming Joint State properties
-low_pass_filter_coeff: 1.5  # Larger --> trust the filtered data more, trust the measurements less.
 
 ## MoveIt properties
 move_group_name: manipulator  # Often 'manipulator' or 'arm'


### PR DESCRIPTION
We have removed the need for various UI parameters, including setting endpoint frames, which now just comes from servo configuration in general. I have also removed servo params that have been removed since the migration to new MoveIt Servo.