### PR TITLE
Enable UR e-Series tool comms through wrist serial port

### DIFF
--- a/src/picknik_ur_base_config/description/picknik_ur.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur.xacro
@@ -13,10 +13,9 @@
 
   <xacro:arg name="headless_mode" default="false" />
   <xacro:arg name="robot_ip" default="0.0.0.0" />
-
-  <xacro:arg name="tool_usb_port" default="/dev/ttyUSB0" />
   <xacro:arg name="use_tool_communication" default="false" />
   <xacro:arg name="tool_voltage" default="0" />
+  <xacro:arg name="tool_device_name" default="/dev/ttyUSB0" />
 
   <xacro:if value="$(arg has_tool_changer)">
     <xacro:property name="camera_adapter_parent" value="tool_changer_tool0" />
@@ -57,6 +56,9 @@
     initial_positions="${xacro.load_yaml(initial_positions_file)}"
     headless_mode="$(arg headless_mode)"
     robot_ip="$(arg robot_ip)"
+    use_tool_communication:="$(arg use_tool_communication)"
+    tool_voltage:="$(arg tool_voltage)"
+    tool_device_name:="$(arg tool_device_name)"
     script_filename="$(find ur_robot_driver)/resources/ros_control.urscript"
     output_recipe_filename="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"
     input_recipe_filename="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"
@@ -88,7 +90,7 @@
   <xacro:ur_to_robotiq prefix="" connected_to="realsense_camera_adapter_tool0" rotation="0" />
 
   <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" 
-    parent="gripper_mount_link" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg tool_usb_port)">
+    parent="gripper_mount_link" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg tool_device_name)">
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:robotiq_gripper>
 

--- a/src/picknik_ur_base_config/description/picknik_ur.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur.xacro
@@ -14,6 +14,10 @@
   <xacro:arg name="headless_mode" default="false" />
   <xacro:arg name="robot_ip" default="0.0.0.0" />
 
+  <xacro:arg name="tool_usb_port" default="/dev/ttyUSB0" />
+  <xacro:arg name="use_tool_communication" default="false" />
+  <xacro:arg name="tool_voltage" default="0" />
+
   <xacro:if value="$(arg has_tool_changer)">
     <xacro:property name="camera_adapter_parent" value="tool_changer_tool0" />
   </xacro:if>
@@ -55,7 +59,10 @@
     robot_ip="$(arg robot_ip)"
     script_filename="$(find ur_robot_driver)/resources/ros_control.urscript"
     output_recipe_filename="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"
-    input_recipe_filename="$(find ur_robot_driver)/resources/rtde_input_recipe.txt">
+    input_recipe_filename="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"
+    use_tool_communication="true"
+    tool_voltage="$(arg tool_voltage)"
+    tool_device_name="$(arg tool_usb_port)">
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:ur_robot>
 
@@ -81,7 +88,7 @@
   <xacro:ur_to_robotiq prefix="" connected_to="realsense_camera_adapter_tool0" rotation="0" />
 
   <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" 
-    parent="gripper_mount_link" use_fake_hardware="$(arg use_fake_hardware)" com_port="/dev/ttyUSB0">
+    parent="gripper_mount_link" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg tool_usb_port)">
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:robotiq_gripper>
 

--- a/src/picknik_ur_base_config/description/picknik_ur.xacro
+++ b/src/picknik_ur_base_config/description/picknik_ur.xacro
@@ -56,15 +56,12 @@
     initial_positions="${xacro.load_yaml(initial_positions_file)}"
     headless_mode="$(arg headless_mode)"
     robot_ip="$(arg robot_ip)"
-    use_tool_communication:="$(arg use_tool_communication)"
-    tool_voltage:="$(arg tool_voltage)"
-    tool_device_name:="$(arg tool_device_name)"
+    use_tool_communication="$(arg use_tool_communication)"
+    tool_voltage="$(arg tool_voltage)"
+    tool_device_name="$(arg tool_device_name)"
     script_filename="$(find ur_robot_driver)/resources/ros_control.urscript"
     output_recipe_filename="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"
-    input_recipe_filename="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"
-    use_tool_communication="true"
-    tool_voltage="$(arg tool_voltage)"
-    tool_device_name="$(arg tool_usb_port)">
+    input_recipe_filename="$(find ur_robot_driver)/resources/rtde_input_recipe.txt">
     <origin xyz="0 0 0" rpy="0 0 0" />
   </xacro:ur_robot>
 

--- a/src/picknik_ur_base_config/launch/robot_drivers_to_persist.launch.py
+++ b/src/picknik_ur_base_config/launch/robot_drivers_to_persist.launch.py
@@ -33,7 +33,7 @@ from launch_ros.actions import Node
 from launch.substitutions import ThisLaunchFileDir
 from launch.launch_description_sources import AnyLaunchDescriptionSource
 
-from moveit_studio_utils_py.launch_common import empty_gen, get_launch_file
+from moveit_studio_utils_py.launch_common import empty_gen
 from moveit_studio_utils_py.system_config import (
     SystemConfigParser,
 )

--- a/src/picknik_ur_base_config/launch/robot_drivers_to_persist.launch.py
+++ b/src/picknik_ur_base_config/launch/robot_drivers_to_persist.launch.py
@@ -28,6 +28,7 @@
 
 
 from launch import LaunchDescription
+from launch.actions import ExecuteProcess
 from launch_ros.actions import Node
 
 from moveit_studio_utils_py.launch_common import empty_gen
@@ -67,9 +68,22 @@ def generate_launch_description():
         ],
     )
 
+    # This command is needed when using direct connection to the end effector rather than a
+    # USB to serial adapter (which is where the default port name of /dev/ttyUSB0 comes from).
+    start_tool_comms = ExecuteProcess(
+        name="start_tool_comms",
+        cmd=[
+            [
+                "socat pty,link=/tmp/ttyUR,raw,ignoreeof,waitslave tcp:192.168.1.102:54321"
+            ]
+        ],
+        shell=True,
+    )
+
     nodes_to_launch = [
         dashboard_client_node,
         protective_stop_manager_node,
+        start_tool_comms,
     ]
 
     return LaunchDescription(nodes_to_launch)

--- a/src/picknik_ur_base_config/launch/ur_tool_comms.launch.xml
+++ b/src/picknik_ur_base_config/launch/ur_tool_comms.launch.xml
@@ -1,0 +1,9 @@
+<launch>
+    <arg name="robot_ip" description="IP address of the UR robot controller."/>
+    <arg name="tool_tcp_port" default="54321" description="Port for tool comms."/>
+    <arg name="tool_device_name" description="Device name to use for tool comms"/>
+    <executable
+      cmd="socat pty,link=$(var tool_device_name),raw,ignoreeof,waitslave tcp:$(var robot_ip):$(var tool_tcp_port)"
+      output="both"
+      shell="true"/>
+</launch>

--- a/src/picknik_ur_base_config/launch/ur_tool_comms.launch.xml
+++ b/src/picknik_ur_base_config/launch/ur_tool_comms.launch.xml
@@ -1,7 +1,7 @@
 <launch>
     <arg name="robot_ip" description="IP address of the UR robot controller."/>
-    <arg name="tool_tcp_port" default="54321" description="Port for tool comms."/>
-    <arg name="tool_device_name" description="Device name to use for tool comms"/>
+    <arg name="tool_tcp_port" default="54321" description="Port for tool communications."/>
+    <arg name="tool_device_name" description="Device name to use for tool communications."/>
     <executable
       cmd="socat pty,link=$(var tool_device_name),raw,ignoreeof,waitslave tcp:$(var robot_ip):$(var tool_tcp_port)"
       output="both"


### PR DESCRIPTION
- Add a launch file that runs the same command as [the UR driver's tool comms script](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/017a54c3991cb3f576d1d6dc0e7d039ef0770826/ur_robot_driver/scripts/tool_communication.py), but with `shell=True`. This is needed to let the `socat` command work correctly when running within a Docker container.
- Update the UR base config package to expose the options that configure UR tool comms.