### PR TITLE
Replace GetSynchronizedCameraTopics with GetPointCloud in scan and plan Objective.

### DIFF
--- a/src/picknik_ur_gazebo_scan_and_plan_config/objectives/object_inspection.xml
+++ b/src/picknik_ur_gazebo_scan_and_plan_config/objectives/object_inspection.xml
@@ -5,13 +5,13 @@
     <Control ID="Sequence" name="TopLevelSequence">
       <Action ID="ClearSnapshot"/>
       <Action ID="MoveToWaypoint" waypoint_name="Look at Object" planning_group_name="manipulator" controller_names="/joint_trajectory_controller /robotiq_gripper_controller" use_all_planners="false" constraints=""/>
-      <SubTree ID="EstimateObjectPose" object_model_file_path="/opt/overlay_ws/install/picknik_accessories/share/picknik_accessories/descriptions/miscellaneous/farnese-hercules-head.stl" guess_position="-0.5;0.0;0.0" guess_orientation="0.0;0.0;0.6442177;0.7648422" icp_max_correspondence_distance="0.5" model_to_real_pose="{model_to_real_pose}"/>
+      <SubTree ID="EstimateObjectPose" object_model_file_path="/opt/overlay_ws/install/picknik_accessories/share/picknik_accessories/descriptions/miscellaneous/farnese-hercules-head.stl" guess_position="-0.5;0.0;0.0" guess_orientation="0.0;0.0;0.6442177;0.7648422" icp_max_correspondence_distance="0.5" model_to_real_pose="{model_to_real_pose}" _collapsed="true"/>
       <Action ID="LoadPoseStampedVectorFromYaml" file_path="/opt/overlay_ws/install/picknik_ur_gazebo_scan_and_plan_config/share/picknik_ur_gazebo_scan_and_plan_config/objectives/trajectory_around_hercules.yaml" output="{pose_stamped_msgs}"/>
       <Decorator ID="ForEachPoseStamped" vector_in="{pose_stamped_msgs}" out="{trajectory_pose}">
         <Control ID="Sequence">
           <Action ID="TransformPoseWithPose" input_pose="{trajectory_pose}" transform_pose="{model_to_real_pose}" output_pose="{target_pose}"/>
           <SubTree ID="MoveToPose" target_pose="{target_pose}"/>
-          <Action ID="GetSynchronizedCameraTopics" point_cloud_topic_name="/wrist_mounted_camera/depth/color/points" rgb_image_topic_name="/wrist_mounted_camera/color/image_raw" rgb_camera_info_topic_name="/wrist_mounted_camera/color/camera_info" point_cloud="{point_cloud}" rgb_image="{rgb_image}" rgb_camera_info="{rgb_camera_info}"/>
+          <Action ID="GetPointCloud" topic_name="/wrist_mounted_camera/depth/color/points" message_out="{point_cloud}"/>
           <Action ID="TransformPointCloudFrame" input_cloud="{point_cloud}" target_frame="world" output_cloud="{point_cloud_world}"/>
           <Action ID="AddPointCloudToVector" point_cloud="{point_cloud_world}" point_cloud_vector="{point_cloud_vector}"/>
         </Control>
@@ -34,7 +34,7 @@
   <BehaviorTree ID="EstimateObjectPose">
     <Control ID="Sequence">
       <Action ID="LoadPointCloudFromFile" file_path="{object_model_file_path}" frame_id="world" num_sampled_points="10000" random_seed="1234" point_cloud="{model_point_cloud}" scale="1.0" color="255;150;0"/>
-      <Action ID="GetSynchronizedCameraTopics" point_cloud_topic_name="/wrist_mounted_camera/depth/color/points" rgb_image_topic_name="/wrist_mounted_camera/color/image_raw" rgb_camera_info_topic_name="/wrist_mounted_camera/color/camera_info" point_cloud="{point_cloud}" rgb_image="{rgb_image}" rgb_camera_info="{rgb_camera_info}"/>
+      <Action ID="GetPointCloud" topic_name="/wrist_mounted_camera/depth/color/points" message_out="{point_cloud}"/>
       <Action ID="TransformPointCloudFrame" input_cloud="{point_cloud}" target_frame="world" output_cloud="{point_cloud}"/>
       <Action ID="CreateStampedPose" reference_frame="world" position_xyz="{guess_position}" orientation_xyzw="{guess_orientation}" stamped_pose="{object_stamped_pose_estimate}"/>
       <Action ID="TransformPointCloud" input_cloud="{model_point_cloud}" transform_pose="{object_stamped_pose_estimate}" output_cloud="{model_point_cloud}"/>


### PR DESCRIPTION
Fixes #5543.

## How to test
Start Studio with picknik_ur_gazebo_scan_and_plan_config. Run the "Object Inspection" Objective. There should be not camera topics synchronization error. 

## After merging
All changes should be based on the `v2.11` branch:
* Update submodules in [picknik_ur5e_configs](https://github.com/PickNikRobotics/picknik_ur5e_configs) to point to the commit resulting from this PR.
* Update submodules in [moveit_studio](https://github.com/PickNikRobotics/moveit_studio) to point to the commit with the change above.