### PR TITLE
Update sample_april_tag behavior

### DIFF
--- a/src/picknik_ur_gazebo_config/objectives/sample_april_tag.xml
+++ b/src/picknik_ur_gazebo_config/objectives/sample_april_tag.xml
@@ -13,7 +13,7 @@
             <Action ID="GetDetectionPose" detections="{detections}" target_id="{tag_id}" target_label="" detection_pose="{detection_pose}"/>
           </Control>
         </Decorator>
-        <Action ID="AveragePoseStamped" pose_sample="{detection_pose}" avg_pose="{avg_pose}" max_distance="{max_distance}" max_rotation="{max_rotation}"/>
+        <Action ID="AveragePoseStamped" pose_sample="{detection_pose}" avg_pose="{avg_pose}" max_distance="{max_distance}" max_rotation="{max_rotation}" num_samples="{num_cycles}"/>
         <!-- TODO: update this objective to allow rejecting noisy samples but fail after X attempts
         <Fallback name="Average pose or sample more">
             <Action ID="AveragePoseStamped"/>


### PR DESCRIPTION
This PR updates `sample_april_tag.xml` Objective per the updates made to the `AveragePoseStamped` Behavior in this PR: https://github.com/PickNikRobotics/moveit_studio/pull/5700. 

To test:

Launch Studio and ensure the "Sample April Tag" Objective looks like the following:

![image](https://github.com/PickNikRobotics/moveit_studio_ws/assets/5256190/50caff99-d870-4403-942d-bef8919dbe7a)
