### PR TITLE
Use CYCLONE DDS else bad things happen

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,11 +11,30 @@ jobs:
       # TODO this variable is required but github workspace is different
       # see https://github.com/actions/runner/issues/2058
       USER_WS: /github/workspace
+      ROS_DOMAIN_ID: 49
+      ROS_LOCALHOST_ONLY: 1
+      RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
+      CYCLONEDDS_URI: /tmp/cyclonedds.xml
     # TODO: docker tag
     # TODO: example for custom base images
     container: picknikciuser/moveit-studio:main
     steps:
       - uses: actions/checkout@v4
+      # The lo interfaces will not have multicast, and will barf trying to claim a participant index
+      # with the default cyclone dds config. We set one for the unit tests to be able to execute.
+      - name: Configure DDS
+        run: |
+          cat <<EOF > /tmp/cyclonedds.xml
+          <?xml version="1.0" ?>
+          <CycloneDDS xmlns="https://cdds.io/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://cdds.io/config https://raw.githubusercontent.com/eclipse-cyclonedds/cyclonedds/master/etc/cyclonedds.xsd">
+            <Domain id="any">
+              <Discovery>
+                <ParticipantIndex>auto</ParticipantIndex>
+                <MaxAutoParticipantIndex>120</MaxAutoParticipantIndex>
+              </Discovery>
+            </Domain>
+          </CycloneDDS>
+          EOF
       - name: Run colcon build
         run: |
           . /opt/ros/humble/setup.sh
@@ -27,6 +46,7 @@ jobs:
           . /opt/ros/humble/setup.sh
           . /opt/underlay_ws/install/setup.sh
           . /opt/overlay_ws/install/setup.sh
+          . ./install/setup.sh
           colcon test
       - if: always()
         run: |


### PR DESCRIPTION
Using the Default DDS Vendor Fast DDS causes things to segfault :( Also source the current colcon workspace install space for python path