### PR TITLE
get STUDIO_LICENSE_KEY from github secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ jobs:
     env:
       # TODO this variable is required but github workspace is different
       # see https://github.com/actions/runner/issues/2058
+      STUDIO_LICENSE_KEY: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
       USER_WS: /github/workspace
       ROS_DOMAIN_ID: 49
       ROS_LOCALHOST_ONLY: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,9 @@ jobs:
   integration-test-in-studio-container:
     runs-on: ubuntu-latest
     env:
+      STUDIO_LICENSE_KEY: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
       # TODO this variable is required but github workspace is different
       # see https://github.com/actions/runner/issues/2058
-      STUDIO_LICENSE_KEY: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
       USER_WS: /github/workspace
       ROS_DOMAIN_ID: 49
       ROS_LOCALHOST_ONLY: 1


### PR DESCRIPTION
set STUDIO_LICENSE_KEY from a github secrete STUDIO_CI_LICENSE_KEY 
```
STUDIO_LICENSE_KEY: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
```

Now when testing locally via `gh act` the secret must be passed in with `-s`
Also `act` will pick up the `.env` file in the repo root which contains `STUDIO_LICENSE_KEY=` so that must be overridden with `--env-file=/dev/null`

```
gh act -v -j integration-test-in-studio-container --env-file=/dev/null -s STUDIO_CI_LICENSE_KEY=**A VALID KEY GOES HERE**
```