### PR TITLE
Update Sample April Tag objective to fix bug

### DIFF
--- a/src/picknik_ur_gazebo_config/objectives/sample_april_tag.xml
+++ b/src/picknik_ur_gazebo_config/objectives/sample_april_tag.xml
@@ -13,7 +13,7 @@
             <Action ID="GetDetectionPose" detections="{detections}" target_id="{tag_id}" target_label="" detection_pose="{detection_pose}"/>
           </Control>
         </Decorator>
-        <Action ID="AveragePoseStamped" pose_sample="{detection_pose}" avg_pose="{avg_pose}" max_distance="{max_distance}" max_rotation="{max_rotation}" num_samples="{num_cycles}"/>
+        <Action ID="AveragePoseStamped" pose_sample="{detection_pose}" avg_pose="{avg_pose}" max_distance="{max_distance}" max_rotation="{max_rotation}" num_samples="{num_samples}" run_continuously="false"/>
         <!-- TODO: update this objective to allow rejecting noisy samples but fail after X attempts
         <Fallback name="Average pose or sample more">
             <Action ID="AveragePoseStamped"/>


### PR DESCRIPTION
There was a bug with the Sample April Tag Objective. The bug was that the `num_samples` field was set to the wrong value (The input value was supposed to be `num_samples`, not `num_cycles`. `num_samples` is set in the `Pick April Tag Labeled Object` Objective that calls the Sample April Tag Objective as a Sub-Tree), and `run_continuously` wasn't explicitly set. 