### PR TITLE
Read .env to get studio tag

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ STUDIO_CONFIG_PACKAGE=picknik_ur_mock_hw_config
 
 # MoveIt Studio version tag
 # Be careful! Changing this without understanding the consequences may break your installation. 
-STUDIO_DOCKER_TAG=2.11.0
+STUDIO_DOCKER_TAG=main
 
 # Licensing -- enter your MoveIt Studio license below
 STUDIO_LICENSE_KEY=

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,17 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.dotenv.outputs.studio_docker_tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: dotenv
+        uses: falti/dotenv-action@v1.0.4
+
   integration-test-in-studio-container:
+    needs: setup
     runs-on: ubuntu-latest
     env:
       STUDIO_LICENSE_KEY: ${{ secrets.STUDIO_CI_LICENSE_KEY }}
@@ -18,7 +28,7 @@ jobs:
       CYCLONEDDS_URI: /tmp/cyclonedds.xml
     # TODO: docker tag
     # TODO: example for custom base images
-    container: picknikciuser/moveit-studio:main
+    container: picknikciuser/moveit-studio:${{ needs.setup.outputs.image_tag }}
     steps:
       - uses: actions/checkout@v4
       # The lo interfaces will not have multicast, and will barf trying to claim a participant index

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
+  # Run every 6 hours Mon-Fri
+  schedule:
+    - chron: "* */6 * * 1-5"
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Read .env file to get studio tag

- Default main branch to main tag of studio

NOTE:

This change assumes that as part of the release process the .env file
is updated when releases are created to point to the correct studio tag