### PR TITLE
fixup typo from PR #174

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   # Run every 6 hours Mon-Fri
   schedule:
-    - chron: "* */6 * * 1-5"
+    - cron: "* */6 * * 1-5"
 
 jobs:
   setup:


### PR DESCRIPTION
typo: chron -> cron

Schedule jobs are not run as part of the PR found only after merge